### PR TITLE
Add sample/mutation subset support for allele frequency

### DIFF
--- a/src/calculations.cpp
+++ b/src/calculations.cpp
@@ -26,6 +26,10 @@
 #include "grgl/visitor.h"
 #include "util.h"
 
+/**
+ * Visitor that computes allele frequency. Can either be used via downward depth-first search
+ * (start at mutation ndoes) or upward via topological order (start at sample nodes).
+ */
 class AlleleFreqVisitor : public grgl::GRGVisitor {
 public:
     AlleleFreqVisitor() = default;
@@ -34,11 +38,12 @@ public:
                const grgl::NodeID nodeId,
                const grgl::TraversalDirection direction,
                const grgl::DfsPass dfsPass) override {
-        release_assert(direction == grgl::TraversalDirection::DIRECTION_DOWN);
         if (m_samplesBeneath.empty()) {
             m_samplesBeneath.resize(grg->numNodes());
         }
         if (dfsPass == grgl::DfsPass::DFS_PASS_BACK_AGAIN) {
+            // Depth-first search must go down
+            release_assert(direction == grgl::TraversalDirection::DIRECTION_DOWN);
             grgl::NodeIDSizeT samplesBeneath = 0;
             if (grg->isSample(nodeId)) {
                 samplesBeneath++;
@@ -48,6 +53,16 @@ public:
             }
             m_samplesBeneath[nodeId] = samplesBeneath;
             release_assert(samplesBeneath <= grg->numSamples());
+        } else if (dfsPass == grgl::DfsPass::DFS_PASS_NONE) {
+            // Topological order must go up.
+            release_assert(direction == grgl::TraversalDirection::DIRECTION_UP);
+            for (const auto& parent : grg->getUpEdges(nodeId)) {
+                if (grg->isSample(nodeId)) {
+                    m_samplesBeneath[parent]++;
+                } else {
+                    m_samplesBeneath[parent] += m_samplesBeneath[nodeId];
+                }
+            }
         }
         return true;
     }
@@ -55,13 +70,38 @@ public:
     std::vector<grgl::NodeIDSizeT> m_samplesBeneath;
 };
 
-void emitAlleleFrequency(grgl::GRGPtr& grg, std::ostream& outStream) {
+void emitAlleleFrequency(grgl::GRGPtr& grg,
+                         std::ostream& outStream,
+                         std::pair<uint32_t, uint32_t> bpRange,
+                         const grgl::NodeIDList& onlySamples) {
     static constexpr char SEP = '\t';
     AlleleFreqVisitor visitorForDfs;
-    fastCompleteDFS(grg, visitorForDfs);
+    if (bpRange.first == bpRange.second && onlySamples.empty()) {
+        fastCompleteDFS(grg, visitorForDfs);
+    } else if (!onlySamples.empty()) {
+        grg->visitTopo(visitorForDfs, grgl::TraversalDirection::DIRECTION_UP, onlySamples);
+    } else {
+        grgl::NodeIDList seeds;
+        for (const auto& pair : grg->getNodeMutationPairs()) {
+            const grgl::Mutation& mut = grg->getMutationById(pair.second);
+            if (mut.getPosition() >= bpRange.first && mut.getPosition() < bpRange.second &&
+                pair.first != INVALID_NODE_ID) {
+                seeds.push_back(pair.first);
+            }
+        }
+        if (seeds.empty()) {
+            std::cout << "No variant in range" << std::endl;
+            return;
+        }
+        grg->visitDfs(visitorForDfs, grgl::TraversalDirection::DIRECTION_DOWN, seeds);
+    }
     std::map<grgl::Mutation, grgl::NodeIDSizeT> counts;
     for (const auto& pair : grg->getNodeMutationPairs()) {
         const grgl::Mutation& mut = grg->getMutationById(pair.second);
+        if (bpRange.first != bpRange.second &&
+            (bpRange.first > mut.getPosition() || bpRange.second <= mut.getPosition())) {
+            continue;
+        }
         counts.emplace(mut, 0);
         if (pair.first != INVALID_NODE_ID) {
             counts.at(mut) += visitorForDfs.m_samplesBeneath[pair.first];

--- a/src/calculations.h
+++ b/src/calculations.h
@@ -4,6 +4,9 @@
 #include <iosfwd>
 #include "grgl/grg.h"
 
-void emitAlleleFrequency(grgl::GRGPtr& grg, std::ostream& outStream);
+void emitAlleleFrequency(grgl::GRGPtr& grg,
+                        std::ostream& outStream,
+                        std::pair<uint32_t, uint32_t> bpRange,
+                        const grgl::NodeIDList& onlySamples);
 
 #endif /* GRGL_CALCULATIONS_H */

--- a/src/util.h
+++ b/src/util.h
@@ -1,11 +1,14 @@
 #ifndef GRGL_UTIL_H
 #define GRGL_UTIL_H
 
+#include "grgl/grgnode.h"
 #include <cmath>
 #include <cstdint>
+#include <fstream>
 #include <iostream>
 #include <limits>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -106,6 +109,25 @@ inline int32_t getEnvInt(const char* varName, int32_t defaultValue) {
         std::cerr << "Could not parse \"" << varName << "\" as integer" << std::endl;
     }
     return result;
+}
+
+inline grgl::NodeIDList loadNodeIDs(const std::string& filename) {
+    grgl::NodeIDList result;
+    std::ifstream infile(filename);
+    std::string line;
+    while (std::getline(infile, line)) {
+        if (line.empty()) {
+            continue;
+        }
+        uint32_t value = 0;
+        if (!parseExactUint32(line, value)) {
+            std::stringstream ssErr;
+            ssErr << "Invalid unsigned integer in file" << std::endl;
+            throw std::runtime_error(ssErr.str().c_str());
+        }
+        result.emplace_back(value);
+    }
+    return std::move(result);
 }
 
 


### PR DESCRIPTION
Samples are specified by a text file, one ID per line. Right now it uses numerical ID, not the (e.g.) VCF string identifier.

Mutations are specified via range, currently.