### PR TITLE
Add population support to GRG samples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,11 +64,13 @@ endif()
 
 set(GRGL_TEST_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/test_common.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test/unit/test_construct.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/test_bloom_filter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/test_grg.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/test_main.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/test_mutation.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/test_serialize.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test/unit/test_util.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test/unit/test_visitor.cpp
   )
 
@@ -201,6 +203,6 @@ if(ENABLE_TESTS)
 
   # Now simply link against gtest or gtest_main as needed. Eg
   add_executable(grgl_test ${GRGL_TEST_SOURCES})
-  target_link_libraries(grgl_test gtest_main tskit grgl)
+  target_link_libraries(grgl_test gtest_main tskit grgl z ${BGEN_LIBS})
   add_test(NAME grgl_test COMMAND grgl_test)
 endif()

--- a/include/grgl/mut_iterator.h
+++ b/include/grgl/mut_iterator.h
@@ -75,6 +75,8 @@ public:
 
     virtual void getMetadata(size_t& ploidy, size_t& numIndividuals, bool& isPhased) = 0;
 
+    virtual std::vector<std::string> getIndividualIds() = 0;
+
     virtual size_t countMutations() const = 0;
 
     bool next(MutationAndSamples& mutAndSamples, size_t& totalSamples);
@@ -114,6 +116,7 @@ public:
 
     void getMetadata(size_t& ploidy, size_t& numIndividuals, bool& isPhased) override;
     size_t countMutations() const override;
+    std::vector<std::string> getIndividualIds() override;
 
 protected:
     void buffer_next(size_t& totalSamples) override;
@@ -132,8 +135,8 @@ public:
         const char* filename, FloatRange genomeRange, bool binaryMutations, bool emitMissingData, bool flipRefMajor);
 
     void getMetadata(size_t& ploidy, size_t& numIndividuals, bool& isPhased) override;
-
     size_t countMutations() const override;
+    std::vector<std::string> getIndividualIds() override;
 
 protected:
     void buffer_next(size_t& totalSamples) override;
@@ -157,8 +160,8 @@ public:
     ~BGENMutationIterator() override;
 
     void getMetadata(size_t& ploidy, size_t& numIndividuals, bool& isPhased) override;
-
     size_t countMutations() const override;
+    std::vector<std::string> getIndividualIds() override;
 
 protected:
     void buffer_next(size_t& totalSamples) override;

--- a/pygrgl/clicmd/construct.py
+++ b/pygrgl/clicmd/construct.py
@@ -15,20 +15,23 @@ def add_options(subparser):
     subparser.add_argument("--parts", "-p", type=int, default=8,
         help="The number of parts to split the sequence into; defaults to 8")
     subparser.add_argument("--jobs", "-j", type=int, default=1,
-                        help="Number of jobs (threads/cores) to use. Defaults to 1.")
+        help="Number of jobs (threads/cores) to use. Defaults to 1.")
     subparser.add_argument("--trees", "-t", type=int, default=1,
-                        help="Number of trees to use during shape construction. Defaults to 1.")
+        help="Number of trees to use during shape construction. Defaults to 1.")
     subparser.add_argument("--binary-muts", "-b", action="store_true",
-                        help="Use binary mutations (don't track specific alternate alleles).")
+        help="Use binary mutations (don't track specific alternate alleles).")
     subparser.add_argument("--no-file-cleanup", "-c", action="store_true",
-                        help="Do not cleanup intermediate files (for debugging, e.g.).")
+        help="Do not cleanup intermediate files (for debugging, e.g.).")
     subparser.add_argument("--no-maf-flip", action="store_true",
-                        help="Do not switch the reference allele with the major allele")
+        help="Do not switch the reference allele with the major allele")
     subparser.add_argument("--shape-lf-filter", "-f", type=float, default=10.0,
-                        help="During shape construction ignore mutations with counts less than this."
-                             "If value is <1.0 then it is treated as a frequency. Defaults to 10 (count).")
+        help="During shape construction ignore mutations with counts less than this."
+             "If value is <1.0 then it is treated as a frequency. Defaults to 10 (count).")
+    subparser.add_argument("--population-ids", default=None,
+        help="Format: \"filename:fieldname\". Read population ids from the given "
+             "tab-separate file, using the given fieldname.")
     subparser.add_argument("--verbose", "-v", action="store_true",
-                        help="Verbose output, including timing information.")
+        help="Verbose output, including timing information.")
 
 grgl_exe = which("grgl")
 grg_merge_exe = which("grg-merge")
@@ -56,6 +59,8 @@ def build_shape(range_triple, args, input_file):
         command = [grgl_exe, input_file]
         if args.no_maf_flip:
             command.append("--no-maf-flip")
+        if args.population_ids:
+            command.extend(["--population-ids", args.population_ids])
         command.extend(["--lf-filter", str(args.shape_lf_filter)])
         command.extend(["-l", "-s", "-r", f"{base}:{base+pspans}",
                         "-o", out_filename_tree(input_file, part, tnum)])

--- a/src/build_shape.h
+++ b/src/build_shape.h
@@ -23,7 +23,8 @@ MutableGRGPtr createEmptyGRGFromSamples(const std::string& sampleFile,
                                         bool useBinaryMuts,
                                         bool emitMissingData,
                                         bool flipRefMajor,
-                                        double dropBelowThreshold);
+                                        double dropBelowThreshold,
+                                        const std::map<std::string, std::string>& indivIdToPop);
 
 }
 

--- a/test/unit/test_construct.cpp
+++ b/test/unit/test_construct.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <random>
+
+#include "grgl/grg.h"
+#include "build_shape.h"
+#include "testing_utilities.h"
+
+using namespace grgl;
+
+inline std::string randomVcfLine(size_t position, size_t numIndivs) {
+    static std::random_device randDevice;
+    static std::mt19937 generator(randDevice());
+
+    std::uniform_int_distribution<size_t> fnSampler(0, 3);
+    std::stringstream ss;
+    ss << "1\t" << position << "\tV1\tA\tC\t.\tPASS\t.\tGT";
+    for (size_t i = 0; i < numIndivs; i++) {
+        size_t allele = fnSampler(generator);
+        ss << "\t" << (allele & 0x1U) << "|" << ((allele & 0x2U) >> 1U);
+    }
+    ss << "\n";
+    return ss.str();
+}
+
+TEST(Construct, WithPopIds) {
+    std::string vcfHeaderString = 
+        "##fileformat=VCFv4.2\n"
+        "##source=TEST\n"
+        "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tX1\tX2\tX3\tA1\tA2\tB4\tZ1\n"
+    ;
+    const size_t numIndividuals = 7;
+    std::stringstream vcfFileSS;
+    vcfFileSS << vcfHeaderString;
+    vcfFileSS << randomVcfLine(60000, numIndividuals);
+    vcfFileSS << randomVcfLine(60001, numIndividuals);
+    vcfFileSS << randomVcfLine(60002, numIndividuals);
+    vcfFileSS << randomVcfLine(60003, numIndividuals);
+    vcfFileSS << randomVcfLine(60004, numIndividuals);
+    vcfFileSS << randomVcfLine(60005, numIndividuals);
+    vcfFileSS << randomVcfLine(60006, numIndividuals);
+    auto filename = writeTempFile(vcfFileSS.str(), ".vcf");
+    std::map<std::string, std::string> indivIdToPop;
+    FloatRange fullRange;
+
+    // Test1: Incomplete individual -> population map
+    indivIdToPop.emplace("Z1", "Population2");
+    indivIdToPop.emplace("X1", "Population4");
+    EXPECT_THROW(createEmptyGRGFromSamples(filename, fullRange, 8, false, false, false, 0.0,
+                                           indivIdToPop), std::runtime_error);
+
+    // Test2: Complete individual -> population map
+    indivIdToPop.emplace("A2", "Population3");
+    indivIdToPop.emplace("X2", "Population1");
+    indivIdToPop.emplace("B4", "Population3");
+    indivIdToPop.emplace("A1", "Population1");
+    indivIdToPop.emplace("X3", "Population4");
+    auto grg = createEmptyGRGFromSamples(filename, fullRange, 8, false, false, false, 0.0,
+                                         indivIdToPop);
+    ASSERT_EQ(grg->numSamples(), numIndividuals*2);
+    auto popDescriptions = grg->getPopulations();
+    ASSERT_EQ(popDescriptions.size(), 4);
+    ASSERT_EQ(popDescriptions[0], "Population4"); // Based on order of individuals in file
+    // Test a bunch of sample nodes
+    ASSERT_EQ(popDescriptions.at(grg->getNodeData(0).populationId), "Population4");
+    ASSERT_EQ(popDescriptions.at(grg->getNodeData(12).populationId), "Population2");
+    ASSERT_EQ(popDescriptions.at(grg->getNodeData(13).populationId), "Population2");
+    ASSERT_EQ(popDescriptions.at(grg->getNodeData(8).populationId), "Population3");
+
+	remove_file(filename);
+}

--- a/test/unit/test_util.cpp
+++ b/test/unit/test_util.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+#include "util.h"
+#include "testing_utilities.h"
+
+TEST(Util, MapFromTSVGood) {
+    std::string testString = 
+        "sample\tpop\tsuper_pop\trandom\n"
+        "A\tPOP1\tSPOP5\t2342830492\n"
+        "B\tPOP2\tSPOP3\tksdjflksjdf\n"
+    ;
+    auto filename = writeTempFile(testString);
+    auto resultMap = loadMapFromTSV(filename, "sample", "pop");
+    ASSERT_EQ(resultMap.size(), 2);
+    ASSERT_NE(resultMap.find("A"), resultMap.end());
+    ASSERT_NE(resultMap.find("B"), resultMap.end());
+    ASSERT_EQ(resultMap.find("A")->second, "POP1");
+    ASSERT_EQ(resultMap.find("B")->second, "POP2");
+
+    auto otherResultMap = loadMapFromTSV(filename, "random", "super_pop");
+    ASSERT_EQ(otherResultMap.size(), 2);
+    ASSERT_EQ(otherResultMap.find("ksdjflksjdf")->second, "SPOP3");
+    ASSERT_EQ(otherResultMap.find("2342830492")->second, "SPOP5");
+
+	remove_file(filename);
+}
+
+TEST(Util, MapFromTSVBad) {
+    std::string testString = 
+        "sample\tpop\tsuper_pop\trandom\n"
+        "A\tPOP1\tSPOP5\t2342830492\n"
+        "B\tPOP2\tksdjflksjdf\n"
+    ;
+    auto filename = writeTempFile(testString);
+    EXPECT_THROW(loadMapFromTSV(filename, "sample", "pop"), std::runtime_error);
+	remove_file(filename);
+}

--- a/test/unit/testing_utilities.h
+++ b/test/unit/testing_utilities.h
@@ -1,0 +1,31 @@
+#ifndef GRGL_TESTING_UTILITIES_H
+#define GRGL_TESTING_UTILITIES_H
+
+#include <unistd.h>
+#include <string>
+#include <cstring>
+
+static inline std::string writeTempFile(const std::string& contents, std::string ext = "") {
+    constexpr size_t MAX_PATH = 256;
+    char filename[MAX_PATH];
+    strcpy(filename, "grgl_test_XXXXXX");
+    int fd = mkstemp(filename);
+	release_assert(fd > 0);
+    release_assert(contents.size() == write(fd, contents.c_str(), contents.size()));
+    fsync(fd);
+    close(fd);
+
+	if (!ext.empty()) {
+		std::stringstream ss;
+		ss << filename << ext;
+		rename(filename, ss.str().c_str());
+		return ss.str();
+	}
+    return std::string(filename);
+}
+
+static inline void remove_file(const std::string& filename) {
+	unlink(filename.c_str());
+}
+
+#endif /* GRGL_TESTING_UTILITIES_H */


### PR DESCRIPTION
* Add new argument to "grg construct", add unit tests
* "grg construct --population-ids <file:field>" now attaches populations to the data.
* Add population ID map support to grgl executable
* Set populationID on the sample nodes based on the individual IDs.
* Unit tests for the population ID handling in GRG construction and the associated helper functions.
* Add individual ID support to MutationIterator
* Add individual filtering to gconverter