### PR TITLE
Only reconstruct "Up edges" when necessary

### DIFF
--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -349,10 +349,10 @@ using ConstMutableGRGPtr = std::shared_ptr<const MutableGRG>;
 
 class CSRGRG : public GRG {
 public:
-    explicit CSRGRG(size_t numSamples, size_t edgeCount, size_t nodeCount, uint16_t ploidy)
+    explicit CSRGRG(size_t numSamples, size_t edgeCount, size_t nodeCount, uint16_t ploidy, bool loadUpEdges = true)
         : GRG(numSamples, ploidy),
           m_downEdges(edgeCount),
-          m_upEdges(edgeCount),
+          m_upEdges(loadUpEdges ? edgeCount : 0),
           m_downPositions(nodeCount + 2),
           m_upPositions(nodeCount + 2),
           m_nodeData(nodeCount) {}

--- a/src/grg_helpers.h
+++ b/src/grg_helpers.h
@@ -104,7 +104,7 @@ static inline MutableGRGPtr loadMutableGRG(const std::string& filename) {
     return result;
 }
 
-static inline GRGPtr loadImmutableGRG(const std::string& filename) {
+static inline GRGPtr loadImmutableGRG(const std::string& filename, bool loadUpEdges = true) {
     GRGPtr result;
     std::ifstream inStream(filename, std::ios::binary);
     if (!inStream.good()) {
@@ -112,7 +112,7 @@ static inline GRGPtr loadImmutableGRG(const std::string& filename) {
         return result;
     }
     try {
-        result = readImmutableGrg(inStream);
+        result = readImmutableGrg(inStream, loadUpEdges);
     } catch (SerializationFailure& e) {
         std::cerr << "Failed to load GRG: " << e.what() << std::endl;
         return result;

--- a/src/grgp.cpp
+++ b/src/grgp.cpp
@@ -79,7 +79,9 @@ int main(int argc, char** argv) {
     grgl::GRGPtr theGRG;
     START_TIMING_OPERATION();
     if (ends_with(*infile, ".grg")) {
-        theGRG = grgl::loadImmutableGRG(*infile);
+        // We only need up edges if we're calculating subsets via samples.
+        const bool loadUpEdges = (bool)sampleSubset;
+        theGRG = grgl::loadImmutableGRG(*infile, loadUpEdges);
         if (!theGRG) {
             std::cerr << "Failed to load " << *infile << std::endl;
             return 2;

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -338,7 +338,7 @@ PYBIND11_MODULE(_grgl, m) {
         :rtype: pygrgl.MutableGRG
     )^");
 
-    m.def("load_immutable_grg", &grgl::loadImmutableGRG, py::arg("filename"), R"^(
+    m.def("load_immutable_grg", &grgl::loadImmutableGRG, py::arg("filename"), py::arg("load_up_edges") = true, R"^(
         Load a GRG file from disk. Immutable GRGs are much faster to traverse than mutable
         GRGs and take up less RAM, so this is the preferred method if you are using a GRG
         for calculation or annotation, and not modifying the graph structure itself.

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -477,7 +477,8 @@ GRGPtr readImmutableGrg(std::istream& inStream, bool loadUpEdges) {
     assert_deserialization(header.ploidy != 0, "Malformed GRG file: ploidy was 0");
 
     // Construct GRG and allocate all the nodes.
-    CSRGRGPtr grg = std::make_shared<CSRGRG>(header.sampleCount, header.edgeCount, header.nodeCount, header.ploidy);
+    CSRGRGPtr grg =
+        std::make_shared<CSRGRG>(header.sampleCount, header.edgeCount, header.nodeCount, header.ploidy, loadUpEdges);
 
     // The GRG serialization only encodes the down edges, we deserialize them here.
     for (size_t i = 0; i < header.edgeCount; i++) {


### PR DESCRIPTION
The API has a flag that loads them by default, but users can choose. All of the calculations we have implemented only need up edges if you are doing sample-based subset queries.