### PR TITLE
Fix the hashing from the previous PR

### DIFF
--- a/src/build_shape.cpp
+++ b/src/build_shape.cpp
@@ -225,7 +225,9 @@ uint16_t genotypeHashIndex(MutationIterator& mutIterator,
             dropped++;
             continue;
         }
-        const size_t hashInput = std::hash<size_t>{}(variantCount);
+        // std::hash() of an integer is just the integer, and we get better results with a little
+        // bit more random-like behavior.
+        const size_t hashInput = hash_combine(std::hash<size_t>{}(variantCount), 42);
         for (auto sampleId : mutAndSamples.samples) {
             bloomFilters.at(sampleId).addHash(hashInput);
         }


### PR DESCRIPTION
std::hash<size_t> just returns the value. The bloom filters do better with some randomness, so we use the hash_combine function with a non-zero seed.