### PR TITLE
Order mutation IDs, down edges optional, gperf support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ option(ENABLE_CHECKERS "Enable external tools like clang-tidy" OFF)
 option(ENABLE_TESTS "Enable automated test execution" ON)
 option(ENABLE_BGEN "Enable BGEN support" OFF)
 option(ENABLE_GSL "Enable GSL support for stat calculations" OFF)
+option(ENABLE_CPU_PROF "Enable gperftools CPU profiler" OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
@@ -110,6 +111,14 @@ include_directories(${CMAKE_CURRENT_LIST_DIR}/include/
 if (${ENABLE_BGEN})
   set(BGEN_LIBS bgen)
   add_compile_options(-DBGEN_ENABLED=1)
+endif()
+
+# In order to use this, grab https://github.com/gperftools/gperftools/releases/download/gperftools-2.15/gperftools-2.15.tar.gz
+# and unzip it to the top-level grgl repo directory, and do "./configure && make"
+if (${ENABLE_CPU_PROF})
+  include_directories(${CMAKE_CURRENT_LIST_DIR}/gperftools-2.15/src/)
+  add_compile_options(-g) # Turn on symbols (but not debug mode)
+  set(GRGP_LIBS ${CMAKE_CURRENT_LIST_DIR}/gperftools-2.15/.libs/libprofiler.a unwind)
 endif()
 
 # We don't need AMPL bindings from gsl.

--- a/include/grgl/mutation.h
+++ b/include/grgl/mutation.h
@@ -33,6 +33,12 @@ constexpr EXTERNAL_ID NO_ORIGINAL_ID = -1;
 class Mutation;
 
 using MutationId = uint32_t;
+constexpr MutationId INVALID_MUTATION_ID = std::numeric_limits<MutationId>::max();
+constexpr MutationId MAX_MUTATION_ID = INVALID_MUTATION_ID - 1;
+
+using BpPosition = uint64_t;
+constexpr BpPosition INVALID_POSITION = std::numeric_limits<BpPosition>::max();
+constexpr BpPosition MAX_POSITION = INVALID_POSITION - 1;
 
 /**
  * A mutation in the GRG.
@@ -49,12 +55,12 @@ public:
 
     Mutation()
         : m_alleleStorage({}),
-          m_position(std::numeric_limits<uint64_t>::max()),
+          m_position(INVALID_POSITION),
           m_time(-1.0),
           m_originalId(NO_ORIGINAL_ID),
           m_refPosition(0) {}
 
-    Mutation(uint64_t position, std::string allele)
+    Mutation(BpPosition position, std::string allele)
         : m_alleleStorage({}),
           m_position(position),
           m_time(-1.0),
@@ -66,7 +72,7 @@ public:
         setAlleleValues(std::move(allele), "");
     }
 
-    Mutation(uint64_t position,
+    Mutation(BpPosition position,
              std::string allele,
              const std::string& refAllele,
              float time = -1.0,
@@ -134,9 +140,9 @@ public:
         setAlleleValues(std::move(rhs.getAllele()), rhs.getRefAllele());
     }
 
-    bool isEmpty() const { return m_position == std::numeric_limits<uint64_t>::max(); }
+    bool isEmpty() const { return m_position == INVALID_POSITION; }
 
-    uint64_t getPosition() const { return m_position; }
+    BpPosition getPosition() const { return m_position; }
 
     float getTime() const { return m_time; }
 
@@ -220,7 +226,7 @@ protected:
         char _b[8];
     } m_alleleStorage; // 8
     static_assert(sizeof(m_alleleStorage) == 8, "Allele storage size changed");
-    uint64_t m_position;      // 8
+    BpPosition m_position;    // 8
     float m_time;             // 4
     EXTERNAL_ID m_originalId; // 4
     uint16_t m_refPosition;   // 2
@@ -249,7 +255,7 @@ struct MutationLtPosAllele {
  */
 template <> struct std::hash<grgl::Mutation> {
     std::size_t operator()(const grgl::Mutation& mut) const noexcept {
-        std::size_t h1 = std::hash<uint64_t>{}(mut.getPosition());
+        std::size_t h1 = std::hash<grgl::BpPosition>{}(mut.getPosition());
         std::size_t h2 = std::hash<std::string>{}(mut.getAllele());
         return grgl::hash_combine(h1, h2);
     }

--- a/include/grgl/serialize.h
+++ b/include/grgl/serialize.h
@@ -54,7 +54,7 @@ void writeGrg(const GRGPtr& grg, std::ostream& out, bool useVarInt = true, bool 
  * @param[in] inStream The (binary) input stream.
  */
 MutableGRGPtr readMutableGrg(std::istream& inStream);
-GRGPtr readImmutableGrg(std::istream& inStream, bool loadUpEdges = true);
+GRGPtr readImmutableGrg(std::istream& inStream, bool loadUpEdges = true, bool loadDownEdges = true);
 
 }; // namespace grgl
 

--- a/src/grg_helpers.h
+++ b/src/grg_helpers.h
@@ -104,7 +104,7 @@ static inline MutableGRGPtr loadMutableGRG(const std::string& filename) {
     return result;
 }
 
-static inline GRGPtr loadImmutableGRG(const std::string& filename, bool loadUpEdges = true) {
+static inline GRGPtr loadImmutableGRG(const std::string& filename, bool loadUpEdges = true, bool loadDownEdges = true) {
     GRGPtr result;
     std::ifstream inStream(filename, std::ios::binary);
     if (!inStream.good()) {
@@ -112,7 +112,7 @@ static inline GRGPtr loadImmutableGRG(const std::string& filename, bool loadUpEd
         return result;
     }
     try {
-        result = readImmutableGrg(inStream, loadUpEdges);
+        result = readImmutableGrg(inStream, loadUpEdges, loadDownEdges);
     } catch (SerializationFailure& e) {
         std::cerr << "Failed to load GRG: " << e.what() << std::endl;
         return result;

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -344,8 +344,12 @@ PYBIND11_MODULE(_grgl, m) {
         :rtype: pygrgl.MutableGRG
     )^");
 
-    m.def("load_immutable_grg", &grgl::loadImmutableGRG, py::arg("filename"),
-          py::arg("load_up_edges") = true, py::arg("load_down_edges") = true, R"^(
+    m.def("load_immutable_grg",
+          &grgl::loadImmutableGRG,
+          py::arg("filename"),
+          py::arg("load_up_edges") = true,
+          py::arg("load_down_edges") = true,
+          R"^(
         Load a GRG file from disk. Immutable GRGs are much faster to traverse than mutable
         GRGs and take up less RAM, so this is the preferred method if you are using a GRG
         for calculation or annotation, and not modifying the graph structure itself.

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -150,6 +150,12 @@ PYBIND11_MODULE(_grgl, m) {
                 num_nodes instead of performing actual graph traversals, depending
                 on what you are trying to accomplish.
             )^")
+        .def_property_readonly("mutations_are_ordered", &grgl::GRG::mutationsAreOrdered, R"^(
+                Returns true if the MutationID order matches the (position, allele)
+                sorted order. That is, MutationID of 0 is the lowest position value
+                and MutationID of num_mutations-1 is the highest. Ties are broken
+                by the lexicographic order of the allele.
+            )^")
         .def_property_readonly("num_nodes", &grgl::GRG::numNodes, R"^(
                 Get the total number of nodes (including sample and mutation nodes)
                 in the GRG.
@@ -338,13 +344,18 @@ PYBIND11_MODULE(_grgl, m) {
         :rtype: pygrgl.MutableGRG
     )^");
 
-    m.def("load_immutable_grg", &grgl::loadImmutableGRG, py::arg("filename"), py::arg("load_up_edges") = true, R"^(
+    m.def("load_immutable_grg", &grgl::loadImmutableGRG, py::arg("filename"),
+          py::arg("load_up_edges") = true, py::arg("load_down_edges") = true, R"^(
         Load a GRG file from disk. Immutable GRGs are much faster to traverse than mutable
         GRGs and take up less RAM, so this is the preferred method if you are using a GRG
         for calculation or annotation, and not modifying the graph structure itself.
 
         :param filename: The file to load.
         :type filename: str
+        :param load_up_edges: If False, do not load the graph "up" edges (saves RAM).
+        :type load_up_edges: bool
+        :param load_down_edges: If False, do not load the graph "down" edges (saves RAM).
+        :type load_down_edges: bool
         :return: The GRG.
         :rtype: pygrgl.GRG
     )^");


### PR DESCRIPTION
Serialize mutations using getMutationsToNodeOrdered() which ensures that the MutationID order matches the (position, allele) sort order upon deserialization. If you have an "old" GRG that does not have sorted MutationIDs, just reserialize it:
`./grgl old.grg -o new.grg`

Make down edges optional on deserialization, just like up edges are.

Compile-time support for gperf CPU profiling in the CMakeList. Just download the appropriate release of gperf source, build it, and then build grgl with -DENABLE_CPU_PROF=ON

A GRG can be checked for mutation ID ordering via
mutationsAreOrdered() (C++) and mutations_are_ordered (Python).