### PR TITLE
Add --maintain-topo and --no-simplify options to grg convert

### DIFF
--- a/include/grgl/ts2grg.h
+++ b/include/grgl/ts2grg.h
@@ -41,8 +41,10 @@ using MutableGRGPtr = std::shared_ptr<MutableGRG>;
 /**
  * Convert a tskit tree-sequence object into a GRG.
  */
-MutableGRGPtr
-convertTreeSeqToGRG(const tsk_treeseq_t* treeSeq, bool binaryMutations = false, bool useNodeTimes = false);
+MutableGRGPtr convertTreeSeqToGRG(const tsk_treeseq_t* treeSeq,
+                                  bool binaryMutations = false,
+                                  bool useNodeTimes = false,
+                                  bool maintainTopology = false);
 
 } // namespace grgl
 

--- a/pygrgl/clicmd/convert.py
+++ b/pygrgl/clicmd/convert.py
@@ -15,6 +15,10 @@ def add_options(subparser):
         help="Use binary mutations (don't track specific alternate alleles).")
     subparser.add_argument("--use-node-times", "-n", action="store_true",
         help="Mark mutations with the time of the node below them, instead of their assigned time.")
+    subparser.add_argument("--no-simplify", "-l", action="store_true",
+        help="Do not remove any \"information-less\" nodes/edges from the graph.")
+    subparser.add_argument("--maintain-topo", "-t", action="store_true",
+        help="Maintain all topology below mutations (at the cost of a larger graph).")
 
 def convert_command(arguments):
     if is_grg(arguments.output_file):
@@ -28,6 +32,10 @@ def convert_command(arguments):
             command_args.append("--binary-muts")
         if arguments.use_node_times:
             command_args.append("--ts-node-times")
+        if arguments.no_simplify:
+            command_args.append("--no-simplify")
+        if arguments.maintain_topo:
+            command_args.append("--maintain-topo")
     elif is_igd(arguments.output_file):
         if is_trees(arguments.input_file):
             print("Can only convert .trees files to GRGs", file=sys.stderr)

--- a/src/grgl.cpp
+++ b/src/grgl.cpp
@@ -103,6 +103,11 @@ int main(int argc, char** argv) {
                            "ts-node-times",
                            "When converting tree-seq, use node times instead of mutation times",
                            {"ts-node-times"});
+    args::Flag maintainTopo(
+        parser,
+        "maintain-topo",
+        "When converting tree-seq, maintain all topology below mutations (at the cost of a larger graph)",
+        {"maintain-topo"});
     args::ValueFlag<std::string> populationIds(parser,
                                                "population-ids",
                                                "Format: \"filename:fieldname\". Read population ids from the given "
@@ -182,7 +187,7 @@ int main(int argc, char** argv) {
         TSKIT_OK_OR_EXIT(tsk_treeseq_load(&treeSeq, infile->c_str(), 0), "Failed to load tree-seq");
 
         try {
-            theGRG = grgl::convertTreeSeqToGRG(&treeSeq, binaryMutations, tsNodeTimes);
+            theGRG = grgl::convertTreeSeqToGRG(&treeSeq, binaryMutations, tsNodeTimes, maintainTopo);
         } catch (grgl::TskitApiFailure& e) {
             std::cerr << e.what();
             return 2;


### PR DESCRIPTION
Conversion from TS to GRG previously ignored topology changes below a mutation _IF_ that topology change did not impact the sample set of the mutation. This manifests when the break and join point of a recombination both occur entirely below a mutation.

You can now run `grg convert --maintain-topo` if you want to instead retain such topology changes. The algorithm change is quite simple: instead of traversing from added/removed edges to their MRCA we instead just traverse all the way to the root(s). The nodes along the way are marked to be split next time they are encountered by a mutation.

On a reasonably large Tree-Seq file (500k samples, 100Mbp len), there is no noticeable timing difference between the two versions of the algorithm.

GRG file size is pretty much the same as well; when you look at the edges/nodes you see the minimal difference:
```
  Original algorithm == Nodes: 3998656, Edges: 13190551
  Maintain topo == Nodes: 4011727, Edges: 13245575
```
But both files are 140Mb

Additionally I exposed the already existing "--no-simplify" option to "grg convert". When you turn off simplification you DO see the size difference:
```
  Maintain topo + no simplify == Nodes: 10648753, Edges: 19297506
```
  File size = 201Mb vs. 140Mb