### PR TITLE
Use ENV instead of pip --install-options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,12 @@ Or for development you can install the folder with pip:
 ```
 python3 -m venv /path/to/MyEnv
 source /path/to/MyEnv/bin/activate
-pip install --config-settings="--build-setting=--copy-bins" -v -e .
-```
-For older versions of pip, you may need to use the below pip command instead:
-```
-pip install --install-option="--copy-bins" -v -e .
+GRGL_COPY_BINS=1 pip install -v -e .
 ```
 
 BGEN support is disabled by default. If you want to enable it:
-* `python setup.py bdist_wheel --bgen`
-* or `pip install --install-option="--bgen" --install-option="--copy-bins" -v -e .`
+* `GRGL_BGEN=1 python setup.py bdist_wheel `
+* or `GRGL_BGEN=1 GRGL_COPY_BINS=1 pip install -v -e .`
 
 Build and installation should take at most a few minutes on the typical computer.
 

--- a/setup.py
+++ b/setup.py
@@ -7,29 +7,23 @@ import subprocess
 import sys
 
 C_MODULE_NAME = "_grgl"
-ARG_DEBUG = "--debug-build"
-ARG_BGEN = "--bgen"
-ARG_COPYBINS = "--copy-bins"
-ARG_GSL = "--gsl"
+
+env_debug = int(os.environ.get("GRGL_DEBUG", 0))
+env_bgen = int(os.environ.get("GRGL_BGEN", 0))
+env_copy_bins = int(os.environ.get("GRGL_COPY_BINS", 0))
+env_gsl = int(os.environ.get("GRGL_GSL", 0))
 
 THISDIR = os.path.realpath(os.path.dirname(__file__))
 
-copy_bins = False # Copy executables to the top-level directory?
+copy_bins = bool(env_copy_bins) # Copy executables to the top-level directory?
 extra_cmake_args = []
 build_type = "Release"
-for arg in sys.argv[1:]:
-    if arg == ARG_DEBUG:
-        build_type = "Debug"
-        sys.argv.remove(ARG_DEBUG)
-    elif arg == ARG_BGEN:
-        extra_cmake_args.append("-DENABLE_BGEN=ON")
-        sys.argv.remove(ARG_BGEN)
-    elif arg == ARG_COPYBINS:
-        copy_bins = True
-        sys.argv.remove(ARG_COPYBINS)
-    elif arg == ARG_GSL:
-        extra_cmake_args.append("-DENABLE_GSL=ON")
-        sys.argv.remove(ARG_GSL)
+if bool(env_debug):
+    build_type = "Debug"
+if bool(env_bgen):
+    extra_cmake_args.append("-DENABLE_BGEN=ON")
+if bool(env_gsl):
+    extra_cmake_args.append("-DENABLE_GSL=ON")
 
 class CMakeExtension(Extension):
     def __init__(self, name, cmake_lists_dir=".", sources=[], extra_executables=[], **kwa):


### PR DESCRIPTION
Pip has removed --install-option. Use environment variables instead to specify build options. This is somewhat cleaner anyways, because the options are specified identically for pip and bdist_wheel.