### PR TITLE
Add dot-product API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt update && \
 COPY . /grgl_src
 
 # Install GRGL python API.
-RUN cd /grgl_src && pip3 install wheel && python3 setup.py bdist_wheel --bgen --gsl
+RUN cd /grgl_src && pip3 install wheel && GRGL_GSL=1 GRGL_BGEN=1 python3 setup.py bdist_wheel
 # Install GRGL command line tools and scripts. Installing the above python package
 # will also build this, but there are some extra tools we might want.
 RUN cd /grgl_src && mkdir cpp_build && cd cpp_build && mkdir /grgl_inst && \

--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -4,7 +4,7 @@ Python API Documentation
 ------------------------
 
 .. automodule:: pygrgl
-    :members: grg_to_cyto_json, load_mutable_grg, load_immutable_grg, save_grg, grg_from_trees, get_bfs_order, get_dfs_order, get_topo_order, INVALID_NODE
+    :members: grg_to_cyto_json, load_mutable_grg, load_immutable_grg, save_grg, grg_from_trees, get_bfs_order, get_dfs_order, get_topo_order, dot_product, INVALID_NODE
 
 .. automodule:: pygrgl.display
     :members: grg_to_cyto

--- a/src/calculations.cpp
+++ b/src/calculations.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "grg_helpers.h"
+#include "grgl/common.h"
 #include "grgl/grg.h"
 #include "grgl/grgnode.h"
 #include "grgl/visitor.h"
@@ -88,6 +89,9 @@ void emitAlleleFrequency(grgl::GRGPtr& grg,
     if (bpRange.first == bpRange.second && onlySamples.empty()) {
         fastCompleteDFS(grg, visitorForDfs);
     } else if (!onlySamples.empty()) {
+        if (bpRange.first != bpRange.second) {
+            throw ApiMisuseFailure("--region and --sample-subset cannot be combined");
+        }
         grg->visitTopo(visitorForDfs, grgl::TraversalDirection::DIRECTION_UP, onlySamples);
     } else {
         grgl::NodeIDList seeds;

--- a/test/endtoend/run_tests.py
+++ b/test/endtoend/run_tests.py
@@ -1,6 +1,8 @@
 import unittest
 import subprocess
 import os
+import numpy as np
+import pygrgl
 from typing import List, Dict, Tuple
 
 JOBS = 4
@@ -21,7 +23,7 @@ def get_freqs(lines: List[str]) -> Dict[Tuple[str, str, str], int]:
         pos, ref, alt, freq, total = line.split("\t")
         if pos == "POSITION":
             continue
-        fmap[(pos, ref, alt)] = int(freq)
+        fmap[(float(pos), ref, alt)] = int(freq)
     return fmap
 
 
@@ -32,18 +34,31 @@ class TestGrgConstruction(unittest.TestCase):
         return os.path.basename(input_file) + ".final.grg"
 
     def test_construct_allele_freq(self):
+        # Create the GRG
         grg_filename = self.construct_grg("test-200-samples.vcf.gz")
+
+        # Use "grg process" to compute allele frequencies.
         af = subprocess.check_output(["grg", "process", "freq", grg_filename])
         saw_freqs = get_freqs(af.decode("utf-8").split("\n"))
+
+        # Compare computed allele frequencys against expected.
         with open(os.path.join(EXPECT_DIR, "test-200-samples.freq.txt")) as f:
             expect_lines = [line for line in f]
         expect_freqs = get_freqs(expect_lines)
-
         saw_keys = set(saw_freqs.keys())
         expect_keys = set(expect_freqs.keys())
         self.assertEqual(saw_keys, expect_keys)
         for k in saw_keys:
             self.assertEqual(saw_freqs[k], expect_freqs[k])
+
+        # Now compute the same values using the dot_product Python API
+        grg = pygrgl.load_immutable_grg(grg_filename)
+        input_vector = np.ones(grg.num_samples)
+        api_result = pygrgl.dot_product(grg, input_vector, pygrgl.TraversalDirection.UP)
+        for i in range(len(api_result)):
+            m = grg.get_mutation_by_id(i)
+            self.assertEqual(api_result[i], expect_freqs[(m.position, m.ref_allele, m.allele)])
+
         if CLEANUP:
             os.remove(grg_filename)
 

--- a/test/unit/test_grg.cpp
+++ b/test/unit/test_grg.cpp
@@ -1,8 +1,15 @@
 #include <gtest/gtest.h>
 
+#include "grgl/common.h"
 #include "grgl/grg.h"
 #include "grgl/grgnode.h"
 #include "grgl/mutation.h"
+#include "grgl/serialize.h"
+
+#include "common_grgs.h"
+#include "grgl/visitor.h"
+
+#include <fstream>
 
 using namespace grgl;
 
@@ -26,4 +33,79 @@ TEST(GRG, Mutations) {
         ASSERT_EQ(g1.getMutationsForNode(1).size(), 1);
         ASSERT_EQ(g1.getNodeMutationPairs().size(), 2);
     }
+}
+
+TEST(GRG, DotProductGood) {
+    GRGPtr grg = depth3BinTree();
+    ASSERT_TRUE(grg->numEdges() == 6);
+    ASSERT_TRUE(grg->numNodes() == 7);
+    // We haven't serialized the GRG ever, so the nodes are unordered.
+    ASSERT_FALSE(grg->nodesAreOrdered());
+
+    Mutation m1(5, "A", "G");
+    grg->addMutation(m1, 1); // Attach directly to sample 1
+    Mutation m2(6, "A", "G");
+    grg->addMutation(m2, 5); // Affects the two samples beneath 5
+    Mutation m3(7, "A", "G");
+    grg->addMutation(m3, 6); // Affects all four samples beneath 6
+
+    // Top-down dot-product
+    std::vector<double> mutValues(3, 1.0); // Input vector [1, 2, 1]
+    mutValues.at(1) = 2.0;
+    auto result1 = grg->dotProduct(mutValues, TraversalDirection::DIRECTION_DOWN);
+    ASSERT_EQ(result1.size(), grg->numSamples());
+    std::vector<double> expect = {1.0, 2.0, 3.0, 3.0};
+    ASSERT_EQ(result1, expect);
+
+    // Bottom-up dot-product (this is just allele freq counts)
+    std::vector<double> sampleValues(4, 1.0); // Input vector [1, 1, 1, 1]
+    auto result2 = grg->dotProduct(sampleValues, TraversalDirection::DIRECTION_UP);
+    ASSERT_EQ(result2.size(), grg->numMutations());
+    expect = {1.0, 2.0, 4.0};
+    ASSERT_EQ(result2, expect);
+
+    // Now we serialize and deserialize the graph, resulting in an _ordered_ GRG which means
+    // the methods invoked under the hood will be slightly different.
+    const char * const testFile = "test.grg.dotproductgood.grg";
+    std::ofstream outStream(testFile);
+    writeGrg(grg, outStream, false, false);
+    outStream.close();
+    std::ifstream inStream(testFile);
+    grg = readImmutableGrg(inStream);
+    ASSERT_TRUE(grg->nodesAreOrdered());
+
+    // Top-down dot-product
+    auto result3 = grg->dotProduct(mutValues, TraversalDirection::DIRECTION_DOWN);
+    ASSERT_EQ(result3.size(), grg->numSamples());
+    expect = {1.0, 2.0, 3.0, 3.0};
+    ASSERT_EQ(result3, expect);
+
+    // Bottom-up dot-product (this is just allele freq counts)
+    auto result4 = grg->dotProduct(sampleValues, TraversalDirection::DIRECTION_UP);
+    ASSERT_EQ(result4.size(), grg->numMutations());
+    expect = {1.0, 2.0, 4.0};
+    ASSERT_EQ(result4, expect);
+}
+
+TEST(GRG, DotProductBad) {
+    GRGPtr grg = depth3BinTree();
+    Mutation m1(5, "A", "G");
+    grg->addMutation(m1, 1); // Attach directly to sample 1
+    Mutation m2(6, "A", "G");
+    grg->addMutation(m2, 5); // Affects the two samples beneath 5
+    Mutation m3(7, "A", "G");
+
+	// Wrong input size
+    std::vector<double> mutValues(4);
+    ASSERT_THROW(
+        grg->dotProduct(mutValues, TraversalDirection::DIRECTION_DOWN),
+        ApiMisuseFailure
+    );
+
+	// Wrong input size
+    std::vector<double> sampleValues(3);
+    ASSERT_THROW(
+        grg->dotProduct(sampleValues, TraversalDirection::DIRECTION_UP),
+        ApiMisuseFailure
+    );
 }


### PR DESCRIPTION
See the API documentation for details. This is a fast, simple way to perform computations on a GRG. Integrated with numpy. On a medium-sized GRG (600MB) this allows you to do allele frequency in 0.42 seconds instead of 48 seconds.

In the future, we may want to add these features:
* Restrict to genome range
* Restrict to sample subset
* Compute multiple values via windows