### PR TITLE
Reorg some markdown content, fix RTD project name

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -12,6 +12,15 @@ source /path/to/MyEnv/bin/activate
 GRGL_COPY_BINS=1 pip install -v -e .
 ```
 
+Other environment variables that control the Python-based build are:
+* `GRGL_GSL=1`: Turns on GNU scientific library, which is used to optionally compute p-values for GWAS
+* `GRGL_DEBUG=1`: Builds the unoptimized version with debug symbols.
+* `GRGL_BGEN=1`: Turns on BGEN input support for GRG construction
+
+## Utilities
+
+There are two utilities `gconverter` and `gindexer` that are built when performing the build either via CMake or python. These utilities can be run with `--help` to see options; they are used for converting files (.vcf, .vcf.gz, and BGEN) to IGD and for indexing BGEN files (which is required before providing a BGEN input to GRG construction).
+
 ## Testing
 
 * C++ unit tests are built as `grgl_test`, and running that executable will tell you the status of those tests.

--- a/README.md
+++ b/README.md
@@ -6,18 +6,28 @@
 GRGL can be used as a library in both C++ and Python. Support is currently limited to Linux and MacOS.
 It contains both an API [(see docs)](https://grgl.readthedocs.io/) and a [set of command-line tools](https://github.com/aprilweilab/grgl/blob/main/GettingStarted.md).
 
-## Building (non-Python)
+## Installing from pip
+
+If you just want to use the tools (e.g., constructing GRG or converting tree-sequence to GRG) and the Python API then you can install via pip (from [PyPi](http://pypi.org/project/pygrgl/)).
+
+```
+pip install pygrgl
+```
+
+This will use prebuilt packages for most modern Linux situations, and will build from source for MacOS. In order to build from source it will require CMake (at least v3.14), zlib development headers, and a clang or GCC compiler that supports C++11.
+
+## Building (C++ only)
 
 Make sure you clone with `git clone --recursive`!
 
-If you only intend to use GRGL from C++, or use the command-line tools, you can just build it via `CMake`:
+If you only intend to use GRGL from C++, you can just build it via `CMake`:
 ```
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j4
 ```
 
-See below to install the libraries and tools to your system. It is recommended to install it to a custom location (prefix) since removing packages installed via `make install` is a pain otherwise. Example:
+See below to install the libraries to your system. It is recommended to install it to a custom location (prefix) since removing packages installed via `make install` is a pain otherwise. Example:
 ```
 mkdir /path/to/grgl_installation/
 mkdir build && cd build
@@ -39,18 +49,7 @@ python setup.py bdist_wheel               # Compiles C++, builds a wheel in the 
 pip install --force-reinstall dist/*.whl  # Install from wheel
 ```
 
-Or for development you can install the folder with pip:
-```
-python3 -m venv /path/to/MyEnv
-source /path/to/MyEnv/bin/activate
-GRGL_COPY_BINS=1 pip install -v -e .
-```
-
-BGEN support is disabled by default. If you want to enable it:
-* `GRGL_BGEN=1 python setup.py bdist_wheel `
-* or `GRGL_BGEN=1 GRGL_COPY_BINS=1 pip install -v -e .`
-
-Build and installation should take at most a few minutes on the typical computer.
+Build and installation should take at most a few minutes on the typical computer. For more details on build options, see DEVELOPING.md.
 
 ## Building (Docker)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,5 +31,4 @@ breathe_default_project = "grgl"
 
 autosummary_generate = True  # Turn on sphinx.ext.autosummary
 
-# Add any paths that contain templates here, relative to this directory.
-#templates_path = ['_templates']
+project = "GRGL"

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ env_gsl = int(os.environ.get("GRGL_GSL", 0))
 
 THISDIR = os.path.realpath(os.path.dirname(__file__))
 
+
 copy_bins = bool(env_copy_bins) # Copy executables to the top-level directory?
 extra_cmake_args = []
 build_type = "Release"
@@ -88,6 +89,8 @@ with open(os.path.join(THISDIR, "include", "grgl", "version.h")) as vf:
         if line.startswith("#define GRGL_MINOR_VERSION"):
             minor_version = int(line.split(" ")[-1])
 version = f"{major_version}.{minor_version}"
+with open(os.path.join(THISDIR, "README.md")) as f:
+    long_description = f.read()
 
 setup(name=PACKAGE_NAME,
       packages=find_packages(),
@@ -106,5 +109,7 @@ setup(name=PACKAGE_NAME,
       ],
       entry_points = {
         "console_scripts": ["grg=pygrgl.cli:main"],
-      }
+      },
+      long_description=long_description,
+      long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
Highlight that `pygrgl` can now be installed directly from PyPi.