### PR TITLE
Add get_mutation_node_pairs API to Python (ordered by mutation)

### DIFF
--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -239,8 +239,18 @@ PYBIND11_MODULE(_grgl, m) {
                 Get a list of pairs (NodeID, MutationID). Each Mutation typically
                 is associated to a single Node, but rarely it can have more than one
                 Node, in which case it will show up in more than one pair.
+                Results are ordered by NodeID, ascending.
 
                 :return: A list of pairs of NodeID and MutationID.
+                :rtype: List[Tuple[int, int]]
+            )^")
+        .def("get_mutation_node_pairs", &grgl::GRG::getMutationsToNodeOrdered, R"^(
+                Get a list of pairs (MutationID, NodeID). Each Mutation typically
+                is associated to a single Node, but rarely it can have more than one
+                Node, in which case it will show up in more than one pair.
+                Results are ordered by MutationID, ascending.
+
+                :return: A list of pairs of MutationID and NodeID.
                 :rtype: List[Tuple[int, int]]
             )^")
         .def("get_mutations_for_node", &grgl::GRG::getMutationsForNode, py::arg("node_id"), R"^(


### PR DESCRIPTION
There are now two APIs for getting the node->mutation mapping:
1. get_node_mutation_pairs(): ordered by nodeID
2. get_mutation_node_pairs(): ordered by mutationID (which is ordered by (position, allele))

The latter is very helpful when looking at per-region or in-order calculations on the graph.