### PR TITLE
Better support for partial/split GRGs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(GRGL_CORE_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/mut_iterator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/serialize.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/ts2grg.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/windowing.cpp
   )
 
 include_directories(${CMAKE_CURRENT_LIST_DIR}/include/

--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -4,19 +4,19 @@ Python API Documentation
 ------------------------
 
 .. automodule:: pygrgl
-    :members: grg_to_cyto_json, load_mutable_grg, load_immutable_grg, save_grg, grg_from_trees, get_bfs_order, get_dfs_order, get_topo_order, dot_product, INVALID_NODE
+    :members: grg_to_cyto_json, load_mutable_grg, load_immutable_grg, save_subset, save_grg, grg_from_trees, get_bfs_order, get_dfs_order, get_topo_order, dot_product, INVALID_NODE
 
 .. automodule:: pygrgl.display
     :members: grg_to_cyto
 
 .. autoclass:: pygrgl.NodeData
-    :members: population_id
+    :members: population_id, num_individual_coals
 
 .. autoclass:: pygrgl.Mutation
     :members: __init__, position, allele, ref_allele, time
 
 .. autoclass:: pygrgl.GRG
-    :members: is_sample, num_samples, nodes_are_ordered, num_nodes, num_edges, num_up_edges, num_down_edges, get_down_edges, get_up_edges, get_node_data, get_sample_nodes, get_root_nodes, get_node_mutation_pairs, get_mutations_for_node, get_mutation_by_id, node_has_mutations, add_population, get_populations, add_mutation, num_mutations
+    :members: is_sample, num_samples, nodes_are_ordered, num_nodes, num_edges, num_up_edges, num_down_edges, get_down_edges, get_up_edges, get_node_data, get_sample_nodes, get_root_nodes, get_node_mutation_pairs, get_mutations_for_node, get_mutation_by_id, node_has_mutations, add_population, get_populations, add_mutation, num_mutations, bp_range, specified_bp_range
 
 .. autoclass:: pygrgl.MutableGRG
     :members: make_node, connect, disconnect, merge

--- a/format-check.sh
+++ b/format-check.sh
@@ -3,5 +3,6 @@
 set -ev
 
 clang-format --dry-run -Werror src/*.cpp
+clang-format --dry-run -Werror src/*.h
 clang-format --dry-run -Werror src/python/*.cpp
 clang-format --dry-run -Werror include/grgl/*.h

--- a/format.sh
+++ b/format.sh
@@ -3,5 +3,6 @@
 set -ev
 
 clang-format -i src/*.cpp
+clang-format -i src/*.h
 clang-format -i src/python/*.cpp
 clang-format -i include/grgl/*.h

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -122,6 +122,18 @@ public:
     }
 
     /**
+     * Get the specified base-pair range this GRG covers as a pair {first, last+1}. Unlike getBPRange,
+     * this function just returns a pair of values that were specified by a tool/user at some point.
+     */
+    std::pair<BpPosition, BpPosition> getSpecifiedBPRange() const { return m_specifiedRange; }
+
+    /**
+     * Set the specified base-pair range this GRG covers as a pair {first, last+1}, i.e. the lower value
+     * is inclusive and the higher value is exclusive.
+     */
+    void setSpecifiedBPRange(std::pair<BpPosition, BpPosition> bpRange) { m_specifiedRange = bpRange; }
+
+    /**
      * Get the NodeIDList for all samples in the graph.
      */
     NodeIDList getSampleNodes() const {
@@ -291,6 +303,9 @@ protected:
     // (Optional) list of population descriptions. The position corresponds to the population
     // ID, which can be used to tag nodes.
     std::vector<std::string> m_populations;
+
+    // The range of base-pair positions covered by this GRG, according to the user/tool that created it.
+    std::pair<BpPosition, BpPosition> m_specifiedRange{};
 
     const size_t m_numSamples;
     const uint16_t m_ploidy;

--- a/include/grgl/mut_iterator.h
+++ b/include/grgl/mut_iterator.h
@@ -84,6 +84,8 @@ public:
 
     size_t numFlippedAlleles() const { return m_flippedAlleles; }
 
+    FloatRange getBpRange() const { return m_genomeRange; }
+
 protected:
     virtual void buffer_next(size_t& totalSamples) = 0;
     virtual void reset_specific() = 0;

--- a/include/grgl/serialize.h
+++ b/include/grgl/serialize.h
@@ -17,6 +17,8 @@
 #ifndef GRG_SERIALIZE_H
 #define GRG_SERIALIZE_H
 
+#include "grgl/grgnode.h"
+#include "grgl/visitor.h"
 #include <iosfwd>
 #include <memory>
 #include <stdexcept>
@@ -38,6 +40,26 @@ using GRGPtr = std::shared_ptr<GRG>;
 using MutableGRGPtr = std::shared_ptr<MutableGRG>;
 
 /**
+ * Simple class to encapsulate the filtering of a GRG to shrink it.
+ */
+class GRGOutputFilter {
+public:
+    GRGOutputFilter()
+        : direction(TraversalDirection::DIRECTION_UP),
+          seedList() {}
+
+    GRGOutputFilter(TraversalDirection dir, const NodeIDList& seeds)
+        : direction(dir),
+          seedList(seeds) {}
+
+    bool isSpecified() const { return !seedList.empty(); }
+
+    TraversalDirection direction;
+    NodeIDList seedList;
+    std::pair<BpPosition, BpPosition> bpRange;
+};
+
+/**
  * Serialize the GRG to the given outstream.
  *
  * @param[in] grg The GRG to be serialized.
@@ -46,7 +68,11 @@ using MutableGRGPtr = std::shared_ptr<MutableGRG>;
  *      integer encoding in the serialization. The only reason to do this is if you are using another
  *      library/program to read GRG files and it does not support variable integer encoding.
  */
-void writeGrg(const GRGPtr& grg, std::ostream& out, bool useVarInt = true, bool allowSimplify = true);
+std::pair<NodeIDSizeT, size_t>
+writeGrg(const GRGPtr& grg, std::ostream& out, bool useVarInt = true, bool allowSimplify = true);
+
+std::pair<NodeIDSizeT, size_t> simplifyAndSerialize(
+    const GRGPtr& grg, std::ostream& outStream, const GRGOutputFilter& filter, bool useVarInt, bool allowSimplify);
 
 /**
  * Deserialize the GRG from the given input stream.

--- a/include/grgl/windowing.h
+++ b/include/grgl/windowing.h
@@ -1,0 +1,73 @@
+/* Genotype Representation Graph Library (GRGL)
+ * Copyright (C) 2024 April Wei
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * should have received a copy of the GNU General Public License
+ * with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef GRG_WINDOWING_H
+#define GRG_WINDOWING_H
+
+#include <cstdint>
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
+#include "grgl/grgnode.h"
+#include "grgl/mutation.h"
+
+namespace grgl {
+
+// We support up to ~65,000 windows, which for human chromosome 2 is about 800bp
+// per window on average.
+using WindowId = uint16_t;
+static constexpr WindowId MAX_WINDOW_ID = std::numeric_limits<WindowId>::max();
+
+struct Window {
+    BpPosition begin; // Inclusive.
+    BpPosition end;   // Exclusive.
+};
+
+using WindowList = std::vector<Window>;
+
+/**
+ * Given a range, split it up into equal-sized windows.
+ *
+ * @param[in] bpRange The base-pair range (usually from GRG::getBPRange() or GRG::getSpecifiedBPRange()).
+ * @param[in] numWindows How many windows to use total.
+ * @param[in] overlap How many windows overlap. numWindows must be divisible by overlap.
+ */
+WindowList windowByBP(std::pair<BpPosition, BpPosition> bpRange, size_t bpPerWindow, size_t overlap);
+
+/**
+ * Given a GRG, split it up into windows of w cM each.
+ */
+WindowList
+windowByCM(std::pair<BpPosition, BpPosition> bpRange, const std::string& mapFile, double cmPerWindow, size_t overlap);
+
+class GRG;
+using GRGPtr = std::shared_ptr<GRG>;
+
+/**
+ * Given a GRG and Window, produce a list of MutationIDs and their corresponding NodeIDs for those mutations,
+ * which fall within the Window.
+ */
+std::vector<std::pair<MutationId, NodeID>> mutationNodePairsForWindow(const GRGPtr& grg, const Window& window);
+
+/**
+ * Given a GRG and Window, produce a list of MutationIDs which fall within the Window.
+ */
+std::vector<MutationId> mutationsForWindow(const GRGPtr& grg, const Window& window);
+
+} // namespace grgl
+
+#endif /* GRG_WINDOWING_H */

--- a/pygrgl/cli.py
+++ b/pygrgl/cli.py
@@ -1,6 +1,7 @@
 from .clicmd import construct
 from .clicmd import convert
 from .clicmd import process
+from .clicmd import split
 from .clicmd.common import which
 import argparse
 import subprocess
@@ -9,6 +10,7 @@ import sys
 CMD_CONVERT = "convert"
 CMD_CONSTRUCT = "construct"
 CMD_PROCESS = "process"
+CMD_SPLIT = "split"
 
 def main():
     parser = argparse.ArgumentParser()
@@ -23,6 +25,9 @@ def main():
     process_parser = subparsers.add_parser(CMD_PROCESS,
         help="Process a GRG to compute information from it.")
     process.add_options(process_parser)
+    split_parser = subparsers.add_parser(CMD_SPLIT,
+        help="Split a GRG into smaller pieces.")
+    split.add_options(split_parser)
     args = parser.parse_args()
 
     if args.version:
@@ -37,7 +42,9 @@ def main():
     elif args.command == CMD_CONSTRUCT:
         construct.from_tabular(args)
     elif args.command == CMD_PROCESS:
-        process.stat_command(args)
+        process.process_command(args)
+    elif args.command == CMD_SPLIT:
+        split.do_split(args)
     else:
         print(f"Invalid command {args.command}", file=sys.stderr)
         parser.print_help()

--- a/pygrgl/clicmd/construct.py
+++ b/pygrgl/clicmd/construct.py
@@ -36,6 +36,8 @@ def add_options(subparser):
         help="Specify an output file instead of using the default name.")
     subparser.add_argument("--verbose", "-v", action="store_true",
         help="Verbose output, including timing information.")
+    subparser.add_argument("--no-merge", action="store_true",
+        help="Do not merge the resulting GRGs (so if you specified \"-p C\" there will be C GRGs).")
 
 grgl_exe = which("grgl")
 grg_merge_exe = which("grg-merge")
@@ -169,22 +171,23 @@ def from_tabular(args):
         print(f"Removing uncompressed input file {input_file} (done with it)")
         os.remove(input_file)
 
-    # Now merge them pairwise.
-    print("Merging...")
-    if args.out_file is not None:
-        final_filename = args.out_file
-    else:
-        final_filename = f"{base_name}.final.grg"
+    if not args.no_merge:
+        # Now merge them pairwise.
+        print("Merging...")
+        if args.out_file is not None:
+            final_filename = args.out_file
+        else:
+            final_filename = f"{base_name}.final.grg"
 
-    command = [grg_merge_exe, "-s", final_filename, ]
-    command.extend(map(lambda part: out_filename(input_file, part), range(0, args.parts)))
-    print(command)
-    final_merge_time = time_call(command)
-    log_time("FINAL_MERGE_TIME", final_merge_time, args.verbose)
+        command = [grg_merge_exe, "-s", final_filename, ]
+        command.extend(map(lambda part: out_filename(input_file, part), range(0, args.parts)))
+        print(command)
+        final_merge_time = time_call(command)
+        log_time("FINAL_MERGE_TIME", final_merge_time, args.verbose)
 
-    if not args.no_file_cleanup:
-        for part in range(0, args.parts):
-            os.remove(out_filename(input_file, part))
+        if not args.no_file_cleanup:
+            for part in range(0, args.parts):
+                os.remove(out_filename(input_file, part))
 
 def main():
     parser = argparse.ArgumentParser(description="Construct a GRG from a VCF file.")

--- a/pygrgl/clicmd/process.py
+++ b/pygrgl/clicmd/process.py
@@ -17,7 +17,7 @@ def add_options(subparser):
         help="The operation to perform on the GRG file")
     subparser.add_argument("grg_file", help="The input GRG file")
 
-def stat_command(arguments):
+def process_command(arguments):
     command_args = [GRGP, arguments.grg_file]
     if arguments.operation == Statistic.GRAPH_STATS:
         command_args.append("-s")

--- a/pygrgl/clicmd/split.py
+++ b/pygrgl/clicmd/split.py
@@ -1,0 +1,21 @@
+from .common import which, time_call
+
+def add_options(subparser):
+    subparser.add_argument("input_file", help="The input GRG file")
+    subparser.add_argument("size_per_grg", type=float,
+        help="The amount of BP or cM per GRG. If --rec-map is specified then this is cM, otherwise BP")
+    subparser.add_argument("--jobs", "-j", type=int, default=1,
+        help="Number of jobs (threads/cores) to use. Defaults to 1.")
+    subparser.add_argument("--rec-map", "-r", default=None,
+        help="Use the given HapMap-style recombination map and interpret the size_per_grg as cM.")
+
+grgl_exe = which("grgl")
+
+def do_split(args):
+    if grgl_exe is None:
+        raise RuntimeError("Could not find 'grgl' executable; please add to your PATH")
+    split_arg = f"{args.size_per_grg}"
+    if args.rec_map is not None:
+        split_arg = f"{args.rec_map}:{split_arg}"
+    cmd = [grgl_exe, args.input_file, "--split", split_arg, "-j", str(args.jobs)]
+    time_call(cmd)

--- a/src/build_shape.cpp
+++ b/src/build_shape.cpp
@@ -26,6 +26,7 @@
 #include "grgl/grg.h"
 #include "grgl/grgnode.h"
 #include "grgl/mut_iterator.h"
+#include "grgl/mutation.h"
 #include "hap_index.h"
 #include "similarity/bf_hash.h"
 #include "util.h"
@@ -306,6 +307,8 @@ MutableGRGPtr createEmptyGRGFromSamples(const std::string& sampleFile,
     }
     std::cout << "Adding GRG shape from genotype hashes..." << std::endl;
     addGrgShapeFromHashing(result, hashIndex, result->getSampleNodes(), tripletLevels);
+    const auto actualRange = mutationIterator->getBpRange();
+    result->setSpecifiedBPRange({(BpPosition)actualRange.start(), (BpPosition)actualRange.end()});
     std::cout << "Done" << std::endl;
 
     return result;

--- a/src/build_shape.h
+++ b/src/build_shape.h
@@ -27,6 +27,6 @@ MutableGRGPtr createEmptyGRGFromSamples(const std::string& sampleFile,
                                         const std::map<std::string, std::string>& indivIdToPop,
                                         size_t tripletLevels = 0);
 
-}
+} // namespace grgl
 
 #endif /* GRG_BUILD_SHAPE_H */

--- a/src/calculations.h
+++ b/src/calculations.h
@@ -1,8 +1,8 @@
 #ifndef GRGL_CALCULATIONS_H
 #define GRGL_CALCULATIONS_H
 
-#include <iosfwd>
 #include "grgl/grg.h"
+#include <iosfwd>
 
 static constexpr char const* USE_RANDOM_PHENOTYPE = "<<random>>";
 
@@ -16,9 +16,6 @@ void emitZygosityInfo(grgl::GRGPtr& grg,
                       std::pair<uint32_t, uint32_t> bpRange,
                       const grgl::NodeIDList& onlySamples);
 
-void emitBeta(const grgl::GRGPtr& grg, 
-              const std::string& phenotype, 
-              std::ostream& outStream,
-              bool betaOnly = false);
+void emitBeta(const grgl::GRGPtr& grg, const std::string& phenotype, std::ostream& outStream, bool betaOnly = false);
 
 #endif /* GRGL_CALCULATIONS_H */

--- a/src/common_visitors.h
+++ b/src/common_visitors.h
@@ -6,9 +6,9 @@
 #include "grgl/visitor.h"
 #include "util.h"
 
+#include <algorithm>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 namespace grgl {
 
@@ -23,9 +23,7 @@ class TopoSampleSetVisitor : public GRGVisitor {
 public:
     TopoSampleSetVisitor() = default;
 
-    virtual void processNode(const grgl::GRGPtr& grg,
-                             const NodeIDList& samplesBeneath,
-                             NodeID nodeId) = 0;
+    virtual void processNode(const grgl::GRGPtr& grg, const NodeIDList& samplesBeneath, NodeID nodeId) = 0;
 
     bool visit(const grgl::GRGPtr& grg,
                const grgl::NodeID nodeId,
@@ -73,9 +71,8 @@ public:
         return true;
     }
 
-    void clearSampleSets() {
-        m_sampleLists.clear();
-    }
+    void clearSampleSets() { m_sampleLists.clear(); }
+
 private:
 #ifdef CLEANUP_SAMPLE_SETS
     std::vector<NodeIDSizeT> m_refCounts;
@@ -83,6 +80,6 @@ private:
     std::vector<NodeIDList> m_sampleLists;
 };
 
-}
+} // namespace grgl
 
 #endif /* GRG_COMMON_VISITORS_H */

--- a/src/grg_helpers.h
+++ b/src/grg_helpers.h
@@ -3,22 +3,22 @@
 
 #include "tskit.h"
 
+#include "common_visitors.h"
 #include "grgl/grg.h"
 #include "grgl/grgnode.h"
 #include "grgl/mutation.h"
 #include "grgl/ts2grg.h"
 #include "grgl/visitor.h"
 #include "util.h"
-#include "common_visitors.h"
 
-#include <iostream>
+#include <chrono>
 #include <fstream>
-#include <sstream>
-#include <vector>
+#include <iomanip>
+#include <iostream>
 #include <map>
 #include <set>
-#include <iomanip>
-#include <chrono>
+#include <sstream>
+#include <vector>
 
 #include "grgl/serialize.h"
 
@@ -34,15 +34,12 @@ inline void fastCompleteDFS(const GRGPtr& grg, GRGVisitor& visitor) {
     }
 }
 
-
 class DfsSampleCountVisitor : public grgl::GRGVisitor {
 public:
     DfsSampleCountVisitor() = default;
 
-    bool visit(const GRGPtr& grg,
-               const NodeID nodeId,
-               const TraversalDirection direction,
-               const DfsPass dfsPass) override {
+    bool
+    visit(const GRGPtr& grg, const NodeID nodeId, const TraversalDirection direction, const DfsPass dfsPass) override {
         release_assert(direction == TraversalDirection::DIRECTION_DOWN);
         if (m_sampleCounts.empty()) {
             m_sampleCounts.resize(grg->numNodes());
@@ -60,12 +57,9 @@ public:
     std::vector<NodeIDSizeT> m_sampleCounts;
 };
 
-
 static inline size_t getNaiveEdgeCount(const GRGPtr& grg) {
     DfsSampleCountVisitor countVisitor;
-    grg->visitDfs(countVisitor,
-                   TraversalDirection::DIRECTION_DOWN,
-                   grg->getRootNodes());
+    grg->visitDfs(countVisitor, TraversalDirection::DIRECTION_DOWN, grg->getRootNodes());
     const std::vector<NodeIDSizeT>& sampleCounts = countVisitor.m_sampleCounts;
     size_t edgeCount = 0;
     for (const auto& pair : grg->getNodeMutationPairs()) {
@@ -120,11 +114,21 @@ static inline GRGPtr loadImmutableGRG(const std::string& filename, bool loadUpEd
     return result;
 }
 
-static inline void saveGRG(const GRGPtr& theGRG,
-                           const std::string& filename,
-                           bool allowSimplify = true) {
+static inline std::pair<NodeIDSizeT, NodeIDSizeT>
+saveGRG(const GRGPtr& theGRG, const std::string& filename, bool allowSimplify = true) {
     std::ofstream outStream(filename, std::ios::binary);
-    grgl::writeGrg(theGRG, outStream, true, allowSimplify);
+    return grgl::writeGrg(theGRG, outStream, true, allowSimplify);
+}
+
+static inline void saveGRGSubset(const GRGPtr& theGRG,
+                                 const std::string& filename,
+                                 const TraversalDirection direction,
+                                 const NodeIDList& seedList,
+                                 std::pair<BpPosition, BpPosition> bpRange = {}) {
+    std::ofstream outStream(filename, std::ios::binary);
+    GRGOutputFilter filter(direction, seedList);
+    filter.bpRange = bpRange;
+    grgl::simplifyAndSerialize(theGRG, outStream, filter, true, true);
 }
 
 /**
@@ -134,12 +138,9 @@ static inline void saveGRG(const GRGPtr& theGRG,
 class MutationSampleHasherVisitor : public TopoSampleSetVisitor {
 public:
     explicit MutationSampleHasherVisitor(bool skipRecurrent)
-        : m_skipRecurrent(skipRecurrent) {
-    }
+        : m_skipRecurrent(skipRecurrent) {}
 
-    void processNode(const GRGPtr& grg,
-                     const NodeIDList& samplesBeneath,
-                     const NodeID nodeId) override {
+    void processNode(const GRGPtr& grg, const NodeIDList& samplesBeneath, const NodeID nodeId) override {
         for (const auto mutId : grg->getMutationsForNode(nodeId)) {
             const auto& mutation = grg->getMutationById(mutId);
             if (m_skipRecurrent && mutation.getAllele() == Mutation::ALLELE_0) {
@@ -153,6 +154,7 @@ public:
     }
 
     std::map<Mutation, NodeIDSetOrdered, MutationLtPosAllele> m_mutToSamples;
+
 private:
     bool m_skipRecurrent;
 };
@@ -176,11 +178,8 @@ inline NodeIDSetOrdered setDifference(const NodeIDSetOrdered& set1, const NodeID
  * - They have the same set of samples
  * - The mapping from mutation to sample is the same
  */
-static inline bool equivalentGRGs(
-        const GRGPtr& grg1,
-        const GRGPtr& grg2,
-        std::string& disagreeReason,
-        bool skipRecurrent) {
+static inline bool
+equivalentGRGs(const GRGPtr& grg1, const GRGPtr& grg2, std::string& disagreeReason, bool skipRecurrent) {
     if (grg1->numSamples() != grg2->numSamples()) {
         disagreeReason = "Sample counts differ";
         return false;
@@ -188,14 +187,18 @@ static inline bool equivalentGRGs(
     auto operationStartTime = std::chrono::high_resolution_clock::now();
     MutationSampleHasherVisitor visitor1(skipRecurrent);
     fastCompleteDFS(grg1, visitor1);
-    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - operationStartTime).count();
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - operationStartTime)
+            .count();
     std::cout << "Done collecting from first GRG: " << elapsed << " seconds" << std::endl;
     visitor1.clearSampleSets();
 
     operationStartTime = std::chrono::high_resolution_clock::now();
     MutationSampleHasherVisitor visitor2(skipRecurrent);
     fastCompleteDFS(grg2, visitor2);
-    elapsed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - operationStartTime).count();
+    elapsed =
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - operationStartTime)
+            .count();
     std::cout << "Done collecting from second GRG: " << elapsed << " seconds" << std::endl;
     visitor2.clearSampleSets();
 
@@ -203,8 +206,8 @@ static inline bool equivalentGRGs(
     errorStream << std::fixed << std::setprecision(2);
     bool failed = false;
     if (visitor1.m_mutToSamples.size() != visitor2.m_mutToSamples.size()) {
-        errorStream << "Reachable mutation counts differ: " << visitor1.m_mutToSamples.size()
-            << " vs. " << visitor2.m_mutToSamples.size() << std::endl;
+        errorStream << "Reachable mutation counts differ: " << visitor1.m_mutToSamples.size() << " vs. "
+                    << visitor2.m_mutToSamples.size() << std::endl;
         failed = true;
     }
 
@@ -213,13 +216,14 @@ static inline bool equivalentGRGs(
         const auto& samplesReached = pair.second;
         const auto& otherIt = visitor2.m_mutToSamples.find(mutation);
         if (otherIt == visitor2.m_mutToSamples.end()) {
-            errorStream << "Missing mutation in the second GRG: " << mutation.getPosition()
-                        << "," << mutation.getAllele() << std::endl;;
+            errorStream << "Missing mutation in the second GRG: " << mutation.getPosition() << ","
+                        << mutation.getAllele() << std::endl;
+            ;
             errorStream << "Has " << samplesReached.size() << " samples" << std::endl;
             failed = true;
         } else if (otherIt->second != samplesReached) {
             errorStream << "Mutation (" << mutation.getPosition() << "," << mutation.getAllele()
-                << ") has different reached samples" << std::endl;
+                        << ") has different reached samples" << std::endl;
             errorStream << "Samples in first but not second: ";
             for (const auto& sampleId : setDifference(samplesReached, otherIt->second)) {
                 errorStream << sampleId << ", ";
@@ -246,7 +250,6 @@ inline MutableGRGPtr grgFromTrees(const std::string& filename, bool binaryMutati
     return grgl::convertTreeSeqToGRG(&treeSeq, binaryMutations);
 }
 
-
-}
+} // namespace grgl
 
 #endif /* GRG_HELPERS_H */

--- a/src/hap_helpers.h
+++ b/src/hap_helpers.h
@@ -37,10 +37,7 @@ inline uint32_t countBits(const HaplotypeVector& vect) {
     return count;
 }
 
-inline HaplotypeVector bitwiseIntersect(
-        const HaplotypeVector& vect1,
-        const HaplotypeVector& vect2,
-        size_t& bitsSet) {
+inline HaplotypeVector bitwiseIntersect(const HaplotypeVector& vect1, const HaplotypeVector& vect2, size_t& bitsSet) {
     bitsSet = 0;
     HaplotypeVector result = vect1;
     const size_t minSize = std::min(result.size(), vect2.size());
@@ -65,13 +62,11 @@ inline size_t bitwiseSubtract(HaplotypeVector& first, const HaplotypeVector& sec
     return after;
 }
 
-inline size_t bitwiseHamming(const HaplotypeVector& hash1,
-                             const HaplotypeVector& hash2) {
+inline size_t bitwiseHamming(const HaplotypeVector& hash1, const HaplotypeVector& hash2) {
     size_t dist = 0;
     release_assert(hash1.size() == hash2.size());
     for (size_t i = 0; i < hash1.size(); i++) {
-        static_assert(sizeof(HapVectorT) == 4,
-                      "Optimization for counting set bits assumes 32-bit ints");
+        static_assert(sizeof(HapVectorT) == 4, "Optimization for counting set bits assumes 32-bit ints");
         const uint32_t xorValue = hash1[i] ^ hash2[i];
         // Fun times: https://graphics.stanford.edu/~seander/bithacks.htm
         uint32_t numBits = xorValue - ((xorValue >> 1U) & 0x55555555U);
@@ -88,10 +83,8 @@ inline void setBit(HaplotypeVector& vect, const size_t bitIndex) {
     vect[element] |= mask;
 }
 
-inline size_t bloomFilterCapacity(size_t numBits) {
-    return (numBits + (sizeof(HapVectorT)-1)) / sizeof(HapVectorT);
-}
+inline size_t bloomFilterCapacity(size_t numBits) { return (numBits + (sizeof(HapVectorT) - 1)) / sizeof(HapVectorT); }
 
-}
+} // namespace grgl
 
 #endif /* GRGL_HAP_HELPERS_H */

--- a/src/hap_index.h
+++ b/src/hap_index.h
@@ -1,20 +1,20 @@
 #ifndef GRG_HAP_INDEX_H
 #define GRG_HAP_INDEX_H
 
-#include <vector>
-#include <unordered_map>
-#include <cstdint>
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <list>
+#include <unordered_map>
+#include <vector>
 
 #include "grgl/common.h"
 #include "grgl/grg.h"
 #include "grgl/grgnode.h"
 #include "grgl/mutation.h"
-#include "util.h"
-#include "lean_bk_tree.h"
 #include "hap_helpers.h"
+#include "lean_bk_tree.h"
+#include "util.h"
 
 namespace grgl {
 
@@ -26,8 +26,7 @@ using NodeToHapVect = std::vector<HaplotypeVector>;
 class HaplotypeIndex {
 public:
     explicit HaplotypeIndex(std::function<size_t(const NodeID&, const NodeID&)> distFunc)
-        : m_bkTree(std::move(distFunc)) {
-    }
+        : m_bkTree(std::move(distFunc)) {}
 
     virtual ~HaplotypeIndex() = default;
 
@@ -56,12 +55,13 @@ public:
         std::cout << " -- Index Stats --" << std::endl;
         std::cout << "  -> Comparisons: " << m_comparisons << std::endl;
     }
+
 private:
     LeanBKTree<NodeID> m_bkTree;
     // Keep track of how many comparisons we do.
     size_t m_comparisons{};
 };
 
-}
+} // namespace grgl
 
 #endif /* GRG_HAP_INDEX_H */

--- a/src/lean_bk_tree.h
+++ b/src/lean_bk_tree.h
@@ -11,16 +11,13 @@
 
 namespace grgl {
 
-template <typename ElementType>
-class LeanBKTree;
+template <typename ElementType> class LeanBKTree;
 
-template <typename ElementType>
-class LeanBKTreeNode {
+template <typename ElementType> class LeanBKTreeNode {
 public:
     explicit LeanBKTreeNode(const ElementType& element)
-        : m_elements({element})
-        , m_isDeleted(false) {
-    }
+        : m_elements({element}),
+          m_isDeleted(false) {}
 
     void addElement(ElementType element) {
         if (m_isDeleted) {
@@ -31,13 +28,13 @@ public:
         }
     }
 
-    template <typename Container>
-    void moveElements(Container& result) {
+    template <typename Container> void moveElements(Container& result) {
         for (size_t i = 0; i < m_elements.size(); i++) {
             result.push_back(m_elements[i]);
         }
         m_isDeleted = true;
     }
+
 private:
     using ChildPair = std::pair<size_t, std::shared_ptr<LeanBKTreeNode<ElementType>>>;
 
@@ -51,17 +48,14 @@ private:
     friend class LeanBKTree<ElementType>;
 };
 
-template <typename ElementType>
-class LeanBKTree {
+template <typename ElementType> class LeanBKTree {
 public:
     using NodePointer = std::shared_ptr<LeanBKTreeNode<ElementType>>;
 
     explicit LeanBKTree(std::function<size_t(const ElementType&, const ElementType&)> distFunc)
-        : m_distFunc(distFunc) {
-    }
+        : m_distFunc(distFunc) {}
 
-    NodePointer insert(const ElementType& element,
-                       size_t& comparisons) {
+    NodePointer insert(const ElementType& element, size_t& comparisons) {
         if (!m_rootNode) {
             m_rootNode = std::make_shared<LeanBKTreeNode<ElementType>>(element);
             return m_rootNode;
@@ -90,10 +84,8 @@ public:
         abort();
     }
 
-    std::vector<NodePointer> lookup(const ElementType& queryElement,
-                                    size_t& nearestDistance,
-                                    size_t& comparisons,
-                                    bool collectAll = true) {
+    std::vector<NodePointer>
+    lookup(const ElementType& queryElement, size_t& nearestDistance, size_t& comparisons, bool collectAll = true) {
         size_t distBest = std::numeric_limits<size_t>::max();
         if (!m_rootNode) {
             nearestDistance = distBest;
@@ -131,11 +123,12 @@ public:
         nearestDistance = distBest;
         return results;
     }
+
 private:
     NodePointer m_rootNode{};
     std::function<size_t(const ElementType&, const ElementType&)> m_distFunc;
 };
 
-}
+} // namespace grgl
 
 #endif /* GRGL_LEAN_BK_TREE_H */

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -73,7 +73,10 @@ int main(int argc, char** argv) {
     }
 
     std::ofstream outStream(*outfile, std::ios::binary);
-    grgl::writeGrg(grg1, outStream, true, !noSimplify);
+    auto counts = grgl::writeGrg(grg1, outStream, true, !noSimplify);
+    std::cout << "Wrote simplified GRG with:" << std::endl;
+    std::cout << "  Nodes: " << counts.first << std::endl;
+    std::cout << "  Edges: " << counts.second << std::endl;
     std::cout << "Wrote GRG to " << *outfile << std::endl;
     return 0;
 }

--- a/src/node_unique_hash.h
+++ b/src/node_unique_hash.h
@@ -3,8 +3,8 @@
 
 #include "grgl/grgnode.h"
 
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 #include "picohash.h"
 
@@ -14,9 +14,7 @@ using HashDigest = std::string;
 using DigestToNode = std::unordered_map<HashDigest, NodeID>;
 
 template <typename OrderedContainer>
-inline HashDigest hashNodeSet(
-        const OrderedContainer& nodeIdSet,
-        size_t length = PICOHASH_MD5_DIGEST_LENGTH) {
+inline HashDigest hashNodeSet(const OrderedContainer& nodeIdSet, size_t length = PICOHASH_MD5_DIGEST_LENGTH) {
     HashDigest result;
     result.resize(PICOHASH_MD5_DIGEST_LENGTH);
     picohash_ctx_t hashContext;
@@ -31,6 +29,6 @@ inline HashDigest hashNodeSet(
     return std::move(result);
 }
 
-}
+} // namespace grgl
 
 #endif

--- a/src/pooled_jobs.h
+++ b/src/pooled_jobs.h
@@ -1,0 +1,96 @@
+/* Genotype Representation Graph Library (GRGL)
+ * Copyright (C) 2024 April Wei
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * should have received a copy of the GNU General Public License
+ * with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef GRG_POOLED_JOBS_H
+#define GRG_POOLED_JOBS_H
+
+#include <iostream>
+#include <list>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace grgl {
+
+/**
+ * Conceptually similar to the Python multiprocessing.Pool, except using threads instead of processes.
+ * All of the work must be added to the queue (via addWork) _prior_ to calling doAllWork. This is essentially
+ * just a way to batch a bunch of known work.
+ *
+ * In order to use this, inherit from it and define the processItem method which do a single item's worth of
+ * work. All the synchronization is handled by PooledJobs, _unless_ processing an item requires the use of
+ * shared resources that are not encapsulated by the item type T.
+ */
+template <typename T> class PooledJobs {
+public:
+    PooledJobs() = default;
+    virtual ~PooledJobs() = default;
+
+    PooledJobs(PooledJobs& rhs) = delete;
+    PooledJobs(PooledJobs&& rhs) = delete;
+    PooledJobs& operator=(PooledJobs& rhs) = delete;
+    PooledJobs& operator=(PooledJobs&& rhs) = delete;
+
+    void addWork(T item) {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        m_queue.push_back(std::move(item));
+    }
+
+    void doAllWork(size_t jobs) {
+        if (jobs == 1) {
+            while (!m_queue.empty()) {
+                T nextItem = std::move(m_queue.front());
+                m_queue.pop_front();
+                processItem(std::move(nextItem));
+            }
+        } else {
+            std::vector<std::thread> threadPool;
+            for (size_t i = 0; i < jobs; i++) {
+                threadPool.emplace_back(&PooledJobs::workerMethod, this);
+            }
+            for (size_t i = 0; i < jobs; i++) {
+                threadPool[i].join();
+            }
+        }
+    }
+
+protected:
+    // The worker (a single thread) loops until the queue is empty.
+    void workerMethod() {
+        while (true) {
+            T nextItem; // T needs a default constructor.
+            {
+                std::lock_guard<std::mutex> lock(m_queueMutex);
+                if (m_queue.empty()) {
+                    break;
+                }
+                nextItem = std::move(m_queue.front());
+                m_queue.pop_front();
+            }
+            processItem(std::move(nextItem));
+        }
+    }
+
+    virtual void processItem(T item) = 0;
+
+private:
+    std::mutex m_queueMutex;
+    std::list<T> m_queue;
+};
+
+} // namespace grgl
+
+#endif /* GRG_POOLED_JOBS_H */

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -154,6 +154,14 @@ PYBIND11_MODULE(_grgl, m) {
         .def_property_readonly("num_samples", &grgl::GRG::numSamples, R"^(
                 The number of sample nodes in the GRG.
             )^")
+        .def_property_readonly("bp_range", &grgl::GRG::getBPRange, R"^(
+                The range in base-pair positions that this GRG covers, from its list of mutations.
+            )^")
+        .def_property_readonly("specified_bp_range", &grgl::GRG::getSpecifiedBPRange, R"^(
+                The range in base-pair positions that this GRG covers, as specified during the
+                GRG construction. This range may exceed the bp_range if the GRG was constructed
+                from a range of the genome that did not immediately start/end with a mutation.
+            )^")
         .def_property_readonly("nodes_are_ordered", &grgl::GRG::nodesAreOrdered, R"^(
                 Returns true if the NodeIDs are already in topological order from
                 the bottom-up. If this is true, then the first `S` NodeIDs starting
@@ -392,8 +400,37 @@ PYBIND11_MODULE(_grgl, m) {
     m.def("save_grg", &grgl::saveGRG, py::arg("grg"), py::arg("filename"), py::arg("allow_simplify") = true, R"^(
         Save the GRG to disk, simplifying it (if possible) in the process.
 
+        :param grg: The GRG
+        :type filename: pygrgl.GRG
         :param filename: The file to save to.
         :type filename: str
+        :param allow_simplify: Set to False to disallow removing nodes/edges from the graph that do not
+            significantly contribute to the mutation-to-samples mapping.
+        :type allow_simplify: bool
+    )^");
+
+    m.def("save_subset",
+          &grgl::saveGRGSubset,
+          py::arg("grg"),
+          py::arg("filename"),
+          py::arg("direction"),
+          py::arg("seed_list"),
+          py::arg("bp_range") = std::pair<grgl::BpPosition, grgl::BpPosition>(),
+          R"^(
+        Save a subset of the GRG to disk, specified by a vector masking either mutation IDs or sample IDs.
+
+        :param grg: The GRG
+        :type filename: pygrgl.GRG
+        :param filename: The file to save to.
+        :type filename: str
+        :param direction: Downward means the seeds should be a list of MutationID that should be kept in
+            the graph. Upward means the seeds should be a list of sample NodeID that should be kept.
+        :type direction: pygrgl.TraversalDirection
+        :param seed_list: A list of MutationID or NodeID (see direction parameter).
+        :type seed_list: List[int]
+        :param bp_range: A pair of integers specifying the base-pair range that this GRG covers. This is just
+            meta-data, and does not change the filtering behavior.
+        :type bp_range: Tuple[int, int]
     )^");
 
     m.def("grg_from_trees", &grgl::grgFromTrees, py::arg("filename"), py::arg("binary_mutations") = false, R"^(

--- a/src/tskit_util.h
+++ b/src/tskit_util.h
@@ -3,23 +3,24 @@
 
 #include <tskit.h>
 
-#define TSKIT_OK_OR_EXIT(ok, msg) do { \
-    int tskit_ok_val = (ok); \
-    if (tskit_ok_val != 0) { \
-        std::cerr << msg << ": " << tsk_strerror(tskit_ok_val) << std::endl; \
-        exit(EXIT_FAILURE); \
-    } \
-} while(0)
+#define TSKIT_OK_OR_EXIT(ok, msg)                                                                                      \
+    do {                                                                                                               \
+        int tskit_ok_val = (ok);                                                                                       \
+        if (tskit_ok_val != 0) {                                                                                       \
+            std::cerr << msg << ": " << tsk_strerror(tskit_ok_val) << std::endl;                                       \
+            exit(EXIT_FAILURE);                                                                                        \
+        }                                                                                                              \
+    } while (0)
 
 namespace grgl {
 
 /**
  * The given node is not connected to the given marginal tree.
  */
-inline bool tsIsDisconnected(const tsk_tree_t *tree, const tsk_id_t treeNode) {
+inline bool tsIsDisconnected(const tsk_tree_t* tree, const tsk_id_t treeNode) {
     return (TSK_NULL == tree->parent[treeNode]) && (0 == tree->num_children[treeNode]);
 }
 
-}
+} // namespace grgl
 
 #endif /* GRGL_TSKIT_UTIL_H */

--- a/src/util.h
+++ b/src/util.h
@@ -7,29 +7,31 @@
 #include <fstream>
 #include <iostream>
 #include <limits>
+#include <map>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <map>
-#include <fstream>
 
-#define release_assert(condition) do { \
-    if (!(condition)) { \
-        std::cerr << "release_assert(" #condition ") failed at " << __FILE__ << ":" << __LINE__ << std::endl; \
-        abort(); \
-    } \
-} while(0)
+#include <sys/stat.h>
+#include <sys/types.h>
 
-inline bool ends_with(std::string const &string1, std::string const &string2) {
+#define release_assert(condition)                                                                                      \
+    do {                                                                                                               \
+        if (!(condition)) {                                                                                            \
+            std::cerr << "release_assert(" #condition ") failed at " << __FILE__ << ":" << __LINE__ << std::endl;      \
+            abort();                                                                                                   \
+        }                                                                                                              \
+    } while (0)
+
+inline bool ends_with(std::string const& string1, std::string const& string2) {
     if (string1.length() < string2.length()) {
         return false;
     }
     return (string2 == string1.substr(string1.length() - string2.length()));
 }
 
-template <typename Out>
-inline void split(const std::string &s, char delim, Out result) {
+template <typename Out> inline void split(const std::string& s, char delim, Out result) {
     std::istringstream iss(s);
     std::string item;
     while (std::getline(iss, item, delim)) {
@@ -37,14 +39,13 @@ inline void split(const std::string &s, char delim, Out result) {
     }
 }
 
-inline std::vector<std::string> split(const std::string &s, char delim) {
+inline std::vector<std::string> split(const std::string& s, char delim) {
     std::vector<std::string> elems;
     split(s, delim, std::back_inserter(elems));
     return std::move(elems);
 }
 
-template <typename T>
-static double trailingMean(const std::vector<T>& hist, double tmThreshold) {
+template <typename T> static double trailingMean(const std::vector<T>& hist, double tmThreshold) {
     release_assert(tmThreshold > 0.0 && tmThreshold <= 1.0);
     size_t totalValues = 0;
     for (size_t i = 0; i < hist.size(); i++) {
@@ -74,7 +75,7 @@ inline bool parseExactDouble(const std::string& exactValue, double& result) {
     char* endPtr = nullptr;
     double _result = std::strtod(exactValue.c_str(), &endPtr);
     if (endPtr != (exactValue.c_str() + exactValue.size())) {
-        return false; 
+        return false;
     }
     result = _result;
     return true;
@@ -84,7 +85,7 @@ inline bool parseExactInt32(const std::string& exactValue, int32_t& result) {
     char* endPtr = nullptr;
     auto _result = static_cast<int32_t>(std::strtoul(exactValue.c_str(), &endPtr, 10));
     if (endPtr != (exactValue.c_str() + exactValue.size())) {
-        return false; 
+        return false;
     }
     result = _result;
     return true;
@@ -94,14 +95,24 @@ inline bool parseExactUint32(const std::string& exactValue, uint32_t& result) {
     char* endPtr = nullptr;
     auto _result = static_cast<uint32_t>(std::strtoull(exactValue.c_str(), &endPtr, 10));
     if (endPtr != (exactValue.c_str() + exactValue.size())) {
-        return false; 
+        return false;
+    }
+    result = _result;
+    return true;
+}
+
+inline bool parseExactUint64(const std::string& exactValue, uint64_t& result) {
+    char* endPtr = nullptr;
+    auto _result = static_cast<uint64_t>(std::strtoull(exactValue.c_str(), &endPtr, 10));
+    if (endPtr != (exactValue.c_str() + exactValue.size())) {
+        return false;
     }
     result = _result;
     return true;
 }
 
 inline int32_t getEnvInt(const char* varName, int32_t defaultValue) {
-    const char *value = getenv(varName);
+    const char* value = getenv(varName);
     if (nullptr == value) {
         return defaultValue;
     }
@@ -132,21 +143,35 @@ inline grgl::NodeIDList loadNodeIDs(const std::string& filename) {
     return std::move(result);
 }
 
+template <class T> inline void helper_addToStringMap(T& result, const std::string& v1, const std::string& v2) {
+    result.emplace(v1, v2);
+};
+
+template <>
+inline void helper_addToStringMap(std::vector<std::pair<std::string, std::string>>& result,
+                                  const std::string& v1,
+                                  const std::string& v2) {
+    result.emplace_back(v1, v2);
+};
+
 /**
  * Helper to convert data from a tab-separate file into a string->string map.
  */
-inline std::map<std::string, std::string> loadMapFromTSV(
-        const std::string& filename,
-        const std::string& lhsField,
-        const std::string& rhsField) {
+template <typename MapType = std::map<std::string, std::string>>
+inline MapType loadMapFromTSV(const std::string& filename, const std::string& lhsField, const std::string& rhsField) {
     release_assert(lhsField != rhsField);
     std::ifstream infile(filename);
+    if (!infile) {
+        std::stringstream ssErr;
+        ssErr << "Could not read file " << filename;
+        throw grgl::BadInputFileFailure(ssErr.str().c_str());
+    }
     std::string line;
     size_t numCols = 0;
     size_t lineNum = 0;
     size_t lhsIndex = std::numeric_limits<size_t>::max();
     size_t rhsIndex = std::numeric_limits<size_t>::max();
-    std::map<std::string, std::string> result;
+    MapType result;
     while (std::getline(infile, line)) {
         auto tokens = split(line, '\t');
         if (lineNum == 0) {
@@ -176,11 +201,36 @@ inline std::map<std::string, std::string> loadMapFromTSV(
                 ssErr << "Malformed TSV file: wrong number of columns at line " << lineNum;
                 throw std::runtime_error(ssErr.str());
             }
-            result.emplace(tokens.at(lhsIndex), tokens.at(rhsIndex));
+            helper_addToStringMap(result, tokens.at(lhsIndex), tokens.at(rhsIndex));
         }
         lineNum++;
     }
     return std::move(result);
+}
+
+inline bool pathExists(const std::string& pathname) {
+    struct stat statBuf;
+    return (stat(pathname.c_str(), &statBuf) == 0);
+}
+
+inline void makeDir(const std::string& pathname) {
+    release_assert(0 == mkdir(pathname.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH));
+}
+
+inline std::string removeExt(const std::string& pathname) {
+    size_t pos = pathname.find_last_of('.');
+    if (pos != std::string::npos) {
+        return std::move(pathname.substr(0, pos));
+    }
+    return pathname;
+}
+
+inline std::string basename(const std::string& pathname) {
+    size_t pos = pathname.find_last_of('/');
+    if (pos != std::string::npos) {
+        return std::move(pathname.substr(pos+1));
+    }
+    return pathname;
 }
 
 #endif /* GRGL_UTIL_H */

--- a/src/util.h
+++ b/src/util.h
@@ -228,7 +228,7 @@ inline std::string removeExt(const std::string& pathname) {
 inline std::string basename(const std::string& pathname) {
     size_t pos = pathname.find_last_of('/');
     if (pos != std::string::npos) {
-        return std::move(pathname.substr(pos+1));
+        return std::move(pathname.substr(pos + 1));
     }
     return pathname;
 }

--- a/src/varint.h
+++ b/src/varint.h
@@ -1,9 +1,9 @@
 #ifndef GRG_VARINT_H
 #define GRG_VARINT_H
 
-#include <limits>
-#include <iostream>
 #include <cstdint>
+#include <iostream>
+#include <limits>
 
 namespace grgl {
 
@@ -20,52 +20,45 @@ inline uint64_t readVarInt(std::istream& inStream) {
     if (controlByte <= 240) {
         return static_cast<uint64_t>(controlByte);
     } else if (controlByte <= 248) {
-        return 240 + (256 * (static_cast<uint64_t>(controlByte) - 241))
-            + static_cast<uint64_t>(readByte(inStream));
+        return 240 + (256 * (static_cast<uint64_t>(controlByte) - 241)) + static_cast<uint64_t>(readByte(inStream));
     } else {
         switch (controlByte) {
-            case 249:
-                return 2288 + (256 * (static_cast<uint64_t>(readByte(inStream))))
-                    + static_cast<uint64_t>(readByte(inStream));
-            case 250:
-                return static_cast<uint64_t>(readByte(inStream))
-                    + (static_cast<uint64_t>(readByte(inStream)) << 8U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 16U);
-            case 251:
-                return static_cast<uint64_t>(readByte(inStream))
-                    + (static_cast<uint64_t>(readByte(inStream)) << 8U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 16U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 24U);
-            case 252:
-                return static_cast<uint64_t>(readByte(inStream))
-                    + (static_cast<uint64_t>(readByte(inStream)) << 8U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 16U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 24U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 32U);
-            case 253:
-                return static_cast<uint64_t>(readByte(inStream))
-                    + (static_cast<uint64_t>(readByte(inStream)) << 8U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 16U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 24U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 32U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 40U);
-            case 254:
-                return static_cast<uint64_t>(readByte(inStream))
-                    + (static_cast<uint64_t>(readByte(inStream)) << 8U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 16U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 24U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 32U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 40U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 48U);
-            default:
-                return static_cast<uint64_t>(readByte(inStream))
-                    + (static_cast<uint64_t>(readByte(inStream)) << 8U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 16U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 24U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 32U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 40U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 48U)
-                    + (static_cast<uint64_t>(readByte(inStream)) << 56U);
+        case 249:
+            return 2288 + (256 * (static_cast<uint64_t>(readByte(inStream)))) +
+                   static_cast<uint64_t>(readByte(inStream));
+        case 250:
+            return static_cast<uint64_t>(readByte(inStream)) + (static_cast<uint64_t>(readByte(inStream)) << 8U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 16U);
+        case 251:
+            return static_cast<uint64_t>(readByte(inStream)) + (static_cast<uint64_t>(readByte(inStream)) << 8U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 16U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 24U);
+        case 252:
+            return static_cast<uint64_t>(readByte(inStream)) + (static_cast<uint64_t>(readByte(inStream)) << 8U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 16U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 24U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 32U);
+        case 253:
+            return static_cast<uint64_t>(readByte(inStream)) + (static_cast<uint64_t>(readByte(inStream)) << 8U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 16U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 24U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 32U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 40U);
+        case 254:
+            return static_cast<uint64_t>(readByte(inStream)) + (static_cast<uint64_t>(readByte(inStream)) << 8U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 16U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 24U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 32U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 40U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 48U);
+        default:
+            return static_cast<uint64_t>(readByte(inStream)) + (static_cast<uint64_t>(readByte(inStream)) << 8U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 16U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 24U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 32U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 40U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 48U) +
+                   (static_cast<uint64_t>(readByte(inStream)) << 56U);
         }
     }
 }
@@ -84,12 +77,12 @@ inline void writeVarInt(uint64_t intValue, std::ostream& outStream) {
     if (intValue <= case1) {
         writeByte(static_cast<uint8_t>(intValue), outStream);
     } else if (intValue <= case2) {
-        writeByte(static_cast<uint8_t>((intValue-case1) / 256) + case1 + 1, outStream);
-        writeByte(static_cast<uint8_t>((intValue-case1) % 256), outStream);
+        writeByte(static_cast<uint8_t>((intValue - case1) / 256) + case1 + 1, outStream);
+        writeByte(static_cast<uint8_t>((intValue - case1) % 256), outStream);
     } else if (intValue <= case3) {
         writeByte(static_cast<uint8_t>(249), outStream);
-        writeByte(static_cast<uint8_t>((intValue - (case2+1)) / 256), outStream);
-        writeByte(static_cast<uint8_t>((intValue - (case2+1)) % 256), outStream);
+        writeByte(static_cast<uint8_t>((intValue - (case2 + 1)) / 256), outStream);
+        writeByte(static_cast<uint8_t>((intValue - (case2 + 1)) % 256), outStream);
     } else if (intValue <= std::numeric_limits<uint16_t>::max()) {
         writeByte(static_cast<uint8_t>(250), outStream);
         writeByte(static_cast<uint8_t>(intValue), outStream);
@@ -138,6 +131,6 @@ inline void writeVarInt(uint64_t intValue, std::ostream& outStream) {
     }
 }
 
-}
+} // namespace grgl
 
 #endif /* GRG_VARINT_H */

--- a/src/windowing.cpp
+++ b/src/windowing.cpp
@@ -1,0 +1,157 @@
+/* Genotype Representation Graph Library (GRGL)
+ * Copyright (C) 2024 April Wei
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * should have received a copy of the GNU General Public License
+ * with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "grgl/windowing.h"
+#include "grgl/common.h"
+#include "grgl/grg.h"
+#include "grgl/mutation.h"
+#include "util.h"
+#include <limits>
+#include <sstream>
+
+namespace grgl {
+
+WindowList windowByBP(std::pair<BpPosition, BpPosition> bpRange, size_t bpPerWindow, size_t overlap) {
+    if (overlap == 0) {
+        overlap = 1;
+    }
+    const size_t effectiveBpPerWindow = bpPerWindow / overlap;
+    const size_t numWindows = ((bpRange.second - bpRange.first) + (effectiveBpPerWindow - 1)) / effectiveBpPerWindow;
+    if (numWindows > MAX_WINDOW_ID) {
+        std::stringstream errStr;
+        errStr << "Number of windows must be less than or equal to " << MAX_WINDOW_ID << " (bpPerWindow too small)";
+        throw ApiMisuseFailure(errStr.str().c_str());
+    }
+    WindowList windows(numWindows);
+    for (size_t i = 0; i < windows.size(); i++) {
+        if (i > 0) {
+            windows[i].begin = windows[i - 1].begin + effectiveBpPerWindow;
+        } else {
+            windows[i].begin = bpRange.first;
+        }
+        windows[i].end = windows[i].begin + bpPerWindow;
+    }
+    assert(windows[numWindows - 1].end >= bpRange.second);
+    return std::move(windows);
+}
+
+static inline std::pair<BpPosition, double> parseRow(const std::pair<std::string, std::string>& row,
+                                                     const size_t lineNum) {
+    std::pair<BpPosition, double> result;
+
+#define ERR_LINE(message)                                                                                              \
+    do {                                                                                                               \
+        std::stringstream ssErr;                                                                                       \
+        ssErr << message << " at line " << lineNum;                                                                    \
+        throw BadInputFileFailure(ssErr.str().c_str());                                                                \
+    } while (0)
+
+    if (!parseExactUint64(row.first, result.first)) {
+        ERR_LINE("Invalid position value ");
+    }
+    if (!parseExactDouble(row.second, result.second)) {
+        ERR_LINE("Invalid cumulative cM value ");
+    }
+    return result;
+}
+
+WindowList
+windowByCM(std::pair<BpPosition, BpPosition> bpRange, const std::string& mapFile, double cmPerWindow, size_t overlap) {
+    if (overlap == 0) {
+        overlap = 1;
+    }
+    using MapType = std::vector<std::pair<std::string, std::string>>;
+    const MapType stringPairs = loadMapFromTSV<MapType>(mapFile, "Position(bp)", "Map(cM)");
+
+    const double cmTillNextWindow = cmPerWindow / (double)overlap;
+    BpPosition prevPos = 0;
+    double prevCm = 0.0;
+    double startCm = -1.0;
+    double stopCm = -1.0;
+    size_t lineNum = 1;
+    std::list<Window> pendingWindows;
+    double nextWindowCm = std::numeric_limits<double>::max();
+    WindowList windows;
+    for (const auto& posCmPair : stringPairs) {
+        const auto bpAndCm = parseRow(posCmPair, lineNum);
+        if (bpAndCm.first >= bpRange.first && startCm == -1.0) {
+            // How far into the current span does our start position go.
+            const double x = (double)(bpRange.first - prevPos) / (double)(bpAndCm.first - prevPos);
+            startCm = (x * (bpAndCm.second - prevCm)) + prevCm;
+            nextWindowCm = startCm + cmTillNextWindow;
+            pendingWindows.push_back({bpRange.first, INVALID_POSITION});
+        }
+        if (bpAndCm.first >= bpRange.second && stopCm == -1.0) {
+            // How far into the current span does our end position go.
+            const double x = (double)(bpRange.second - prevPos) / (double)(bpAndCm.first - prevPos);
+            stopCm = (x * (bpAndCm.second - prevCm)) + prevCm;
+            break;
+        }
+        while (bpAndCm.second >= nextWindowCm) {
+            const double x = (double)(nextWindowCm - prevCm) / (double)(bpAndCm.second - prevCm);
+            const BpPosition bpPos = (BpPosition)(x * (double)(bpAndCm.first - prevPos)) + prevPos;
+            if (pendingWindows.size() == overlap) {
+                Window w = pendingWindows.front();
+                pendingWindows.pop_front();
+                w.end = bpPos;
+                windows.push_back(w);
+            }
+            pendingWindows.push_back({bpPos, INVALID_POSITION});
+            assert(pendingWindows.size() <= overlap);
+            nextWindowCm += cmTillNextWindow;
+        }
+        prevPos = bpAndCm.first;
+        prevCm = bpAndCm.second;
+        lineNum++;
+    }
+    if (stopCm == -1.0) {
+        stopCm = prevCm;
+    }
+    while (!pendingWindows.empty()) {
+        Window w = pendingWindows.front();
+        pendingWindows.pop_front();
+        w.end = bpRange.second;
+        windows.push_back(w);
+    }
+
+    return std::move(windows);
+}
+
+std::vector<std::pair<MutationId, NodeID>> mutationNodePairsForWindow(const GRGPtr& grg, const Window& window) {
+    std::vector<std::pair<MutationId, NodeID>> result;
+    for (const auto& nodeAndMutId : grg->getNodeMutationPairs()) {
+        const auto& mutation = grg->getMutationById(nodeAndMutId.second);
+        if (mutation.getPosition() >= window.begin && mutation.getPosition() < window.end) {
+            result.emplace_back(nodeAndMutId.second, nodeAndMutId.first);
+        }
+    }
+    return std::move(result);
+}
+
+std::vector<MutationId> mutationsForWindow(const GRGPtr& grg, const Window& window) {
+    std::vector<MutationId> result;
+    // TODO: this can be sped up if the mutations are known to be ordered by ID, which is the case for
+    // most GRGs (unless we are in the middle of building a GRG, which we can just reject that scenario).
+    for (MutationId mutId = 0; mutId < grg->numMutations(); mutId++) {
+        const auto& mutation = grg->getMutationById(mutId);
+        if (mutation.getPosition() >= window.begin && mutation.getPosition() < window.end) {
+            result.emplace_back(mutId);
+        }
+    }
+    return std::move(result);
+}
+
+} // namespace grgl

--- a/test/endtoend/run_tests.py
+++ b/test/endtoend/run_tests.py
@@ -3,6 +3,7 @@ import subprocess
 import os
 import numpy as np
 import pygrgl
+import glob
 from typing import List, Dict, Tuple
 
 JOBS = 4
@@ -61,6 +62,33 @@ class TestGrgConstruction(unittest.TestCase):
 
         if CLEANUP:
             os.remove(grg_filename)
+
+    def test_split(self):
+        """
+        Verify that splitting a GRG still captures all of the sample->mutation relationships.
+        """
+        # Create the GRG
+        grg_filename = self.construct_grg("test-200-samples.vcf.gz")
+        split_dir = f"{grg_filename}.split"
+        assert not os.path.exists(split_dir), f"{split_dir} already exists; remove it"
+
+        # Split the GRG
+        subprocess.check_output(["grg", "split", "-j", str(4), grg_filename, str(100000)])
+        saw_freqs = {}
+        for grg_part in glob.glob(f"{split_dir}/*.grg"):
+            af = subprocess.check_output(["grg", "process", "freq", grg_part])
+            saw_freqs.update(get_freqs(af.decode("utf-8").split("\n")))
+
+        # Compare computed allele frequencys against expected.
+        with open(os.path.join(EXPECT_DIR, "test-200-samples.freq.txt")) as f:
+            expect_lines = [line for line in f]
+        expect_freqs = get_freqs(expect_lines)
+        saw_keys = set(saw_freqs.keys())
+        expect_keys = set(expect_freqs.keys())
+        self.assertEqual(saw_keys, expect_keys)
+        for k in saw_keys:
+            self.assertEqual(saw_freqs[k], expect_freqs[k])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Splitting a GRG into 1,000 equally sized (w.r.t number of mutations) graphs
produces a total file size almost exactly 2x of the original full GRG. Thus you
can load these GRGs into RAM one at a time, at about 1/500th of the RAM needed
for the full GRG.

There are a few reasons why you might want to split up a GRG:
1. To reduce the RAM usage for a genome-wide calculation. Performing this
calculation on the smaller GRGs will slow it down overall, but you can more or
less control the RAM usage by choosing the split size.
2. If you are performing a calculation that uses windows (regions) of the
genome, it is generally much faster to split the graph by windows first, and
then perform the calculation. And obviously you can do this for overlapping
windows as well (at the cost of some disk space). The reasons it is faster:
locality is significantly better, and the number of uninformative edges that
you need to examine at each node is potentially orders of magnitude smaller
(especially at sample nodes).

You can split a GRG with the new `pygrgl.save_subset()` method, which takes
either a list of MutationIDs or a list of sample NodeIDs, and serializes a
graph with only those roots/leaves. In addition to splitting a GRG into pieces
for performance reasons, you can also use this API to:
1. Remove samples from a GRG.
2. Filter out mutations from a GRG, e.g. based on frequency.

In addition to splitting a GRG after-the-fact, you can now prevent the merge of
partial GRGs during construction via the `--no-merge` flag to the `grg
construct` command. There is also a new command `grg split` which takes
a GRG, a number of windows, an optional recombination map, and will quickly
split the GRG using multiple threads.

In order to better support workflows with partial GRGs, the GRG now stores its
genomic range (in base-pair position). Old GRG files will just use the min/max
position from their Mutations as the range. New GRGs have the option for their
range to be specified, as you might want to indicate what region you
constructed the GRG from (not just the first/last mutation in it).
In Python, you can access these two ranges using the `grg.bp_range` (range as
found in the mutation list) and `grg.specified_bp_range` (range as specified
during construction of the GRG).

The Windowing API (in C++) does support overlapping windows, but this has not
yet been exposed to the `grg split` command, and has not been exposed to
Python yet.

Also: fix a bug in the formatting script and properly format the internal headers
in `src/`