### PR TITLE
Dot-product _always_ uses down edges (even in downward direction)

### DIFF
--- a/src/grg.cpp
+++ b/src/grg.cpp
@@ -200,11 +200,10 @@ void GRG::dotProduct(const double* inputData,
         if (this->nodesAreOrdered()) {
             for (NodeID i = numNodes(); i > 0; i--) {
                 const NodeID nodeId = i - 1;
-                double value = 0.0;
-                for (NodeID parentId : this->getUpEdges(nodeId)) {
-                    value += nodeValues[parentId];
+                const double myValue = nodeValues[nodeId];
+                for (NodeID childId : this->getDownEdges(nodeId)) {
+                    nodeValues[childId] += myValue;
                 }
-                nodeValues[nodeId] += value;
             }
         } else {
             ValueSumVisitor valueSumVisitor(nodeValues);


### PR DESCRIPTION
The dotProduct() API always does a full graph traversal using the node ID ordering (topologically sorted). Previously, when doing an upward traversal it used the down-edges to propagate values, and when doing a downward traversal it used up-edges to propagate values. Now it uses down-edges for both: the downward traversal has to "push" values to its children instead of "pulling" values from its parents.

This turns out to be about 25% faster than the previous way, but the main reason to change this is that the down edges are what is stored on disk, and loading the up-edges essentially doubles the memory usage.