### PR TITLE
Fix bug that was producing extra root nodes during MapMutations

### DIFF
--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -141,7 +141,7 @@ public:
         for (grgl::NodeID i = 0; i < this->numSamples(); i++) {
             result.push_back(i);
         }
-        return result;
+        return std::move(result);
     }
 
     /**
@@ -154,7 +154,7 @@ public:
                 result.push_back(nodeId);
             }
         }
-        return result;
+        return std::move(result);
     }
 
     const std::vector<Mutation>& getMutations() const { return m_mutations; }

--- a/src/calculations.cpp
+++ b/src/calculations.cpp
@@ -170,8 +170,8 @@ void loadPhenotypeData(const std::string& phenotypeTextFile,
         std::vector<std::string> v = split(myText, ' ');
         if (v.size() != 3) {
             std::stringstream ssErr;
-            ssErr << "Each line in phenotype file must have three space-separated columns."
-                  << " Line " << i << " failed this check.";
+            ssErr << "Each line in phenotype file must have three space-separated columns." << " Line " << i
+                  << " failed this check.";
             throw grgl::BadInputFileFailure(ssErr.str().c_str());
         }
         phenVector[i] = std::stof(v[2]);


### PR DESCRIPTION
When we reach a root, and that root covers all the necessary muts, add it to the candidate set.