### PR TITLE
Use C++-style cast to avoid clang-format issue

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,4 +11,5 @@ IndentWidth: 4
 NamespaceIndentation: None
 PointerAlignment: Left
 PackConstructorInitializers: Never
+SpaceAfterCStyleCast: 'false'
 ...

--- a/include/grgl/mutation.h
+++ b/include/grgl/mutation.h
@@ -186,7 +186,7 @@ protected:
         const size_t totalBytes = altAllele.size() + refAllele.size();
         m_refPosition = altAllele.size();
         if (totalBytes > 7) {
-            m_alleleStorage._str = (size_t) new char[totalBytes + 1];
+            m_alleleStorage._str = reinterpret_cast<size_t>(new char[totalBytes + 1]);
             std::memcpy((void*)m_alleleStorage._str, altAllele.c_str(), altAllele.size());
             std::memcpy((void*)(m_alleleStorage._str + m_refPosition), refAllele.c_str(), refAllele.size());
             *(char*)(m_alleleStorage._str + totalBytes) = 0; // null term


### PR DESCRIPTION
Should be using C++-style casts anyways.