### PR TITLE
Add coalescence counting for TS->GRG conversion

### DIFF
--- a/doc/cpp_api.rst
+++ b/doc/cpp_api.rst
@@ -27,9 +27,6 @@ Main GRG Classes
 .. doxygenclass:: grgl::Mutation
     :members:
 
-.. doxygenstruct:: grgl::NodeData
-    :members:
-
 
 Serialization and Conversion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/ts_convert.rst
+++ b/doc/ts_convert.rst
@@ -33,6 +33,12 @@ The following properties of a tree sequence *are* maintained when converted to a
 - All Mutations from the TS are copied into the GRG. Mutations in the TS can have no samples
   reachable beneath them (due to recurrent mutations "blocking" them), and these are copied into
   the GRG as a :py:class:`pygrgl.Mutation` with no associated node in the graph.
+- Recurrent mutations are copied over as-is. This means that two mutations with the same position,
+  but different derived alleles, are in the same tree, affecting the same subset of samples. The
+  GRG will contain both of these Mutation nodes (even if one matches the reference) and the path
+  between the mutations should also be maintained. Many calculations (such as the example allele
+  frequency calculation shown in the documentation) do not adjust for this case, so a few sites
+  will have approximate values when recurrent mutations are present.
 
 The following properties of a tree sequence are *not* maintained when converted to a GRG:
 
@@ -53,3 +59,20 @@ In the presence of recombination you can also end up with a GRG child node conta
 older than a Mutation on the parent node (though rarely). The GRG conversion flag ``--use-node-times``
 can avoid this Mutations-out-of-order problem by associating the coalesence time from the node below
 the Mutation in the TS with the :py:class:`pygrgl.Mutation` in the GRG.
+
+
+Node coalescence counts
+~~~~~~~~~~~~~~~~~~~~~~~
+
+`GWAS <examples_and_applications.html>`_ and zygosity information (see ``grg process zygosity --help``)
+both require the GRG to have coalescence information at each node. This is just a count of the number of
+diploid individuals that coalesced at any given node (both of their haploid samples are reachable from
+the node, but not reachable together from any of the node's children). This information is automatically
+calculated when you construct a GRG via ``grg construct``. In order to get this information in TS-converted
+GRGs, you need to pass ``--ts-coals`` flags to the ``grg convert`` command.
+
+Conversion from tree-sequence to GRG is very fast, on the order of seconds or minutes for very large datasets.
+That said, setting flag ``--ts-coals`` can slow it down significantly, especially for datasets with a
+lot of individual samples.
+
+See also :py:meth:`pygrgl.GRG.get_num_individual_coals` and :py:meth:`pygrgl.GRG.set_num_individual_coals`.

--- a/include/grgl/ts2grg.h
+++ b/include/grgl/ts2grg.h
@@ -44,7 +44,8 @@ using MutableGRGPtr = std::shared_ptr<MutableGRG>;
 MutableGRGPtr convertTreeSeqToGRG(const tsk_treeseq_t* treeSeq,
                                   bool binaryMutations = false,
                                   bool useNodeTimes = false,
-                                  bool maintainTopology = false);
+                                  bool maintainTopology = false,
+                                  bool computeCoals = false);
 
 } // namespace grgl
 

--- a/pygrgl/clicmd/convert.py
+++ b/pygrgl/clicmd/convert.py
@@ -51,6 +51,11 @@ def add_options(subparser):
         action="store_true",
         help="Maintain all topology below mutations (at the cost of a larger graph).",
     )
+    subparser.add_argument(
+        "--ts-coals",
+        action="store_true",
+        help="Compute individual coalescence information at each GRG node (more expensive).",
+    )
 
 
 def convert_command(arguments):
@@ -70,6 +75,8 @@ def convert_command(arguments):
             command_args.append("--no-simplify")
         if arguments.maintain_topo:
             command_args.append("--maintain-topo")
+        if arguments.ts_coals:
+            command_args.append("--ts-coals")
     elif is_igd(arguments.output_file):
         if is_trees(arguments.input_file):
             print("Can only convert .trees files to GRGs", file=sys.stderr)

--- a/src/grg_helpers.h
+++ b/src/grg_helpers.h
@@ -257,13 +257,17 @@ equivalentGRGs(const GRGPtr& grg1, const GRGPtr& grg2, std::string& disagreeReas
     return !failed;
 }
 
-inline MutableGRGPtr grgFromTrees(const std::string& filename, bool binaryMutations = false) {
+inline MutableGRGPtr grgFromTrees(const std::string& filename,
+                                  bool binaryMutations = false,
+                                  bool useNodeTimes = false,
+                                  bool maintainTopology = false,
+                                  bool computeCoals = false) {
     tsk_treeseq_t treeSeq;
     if (0 != tsk_treeseq_load(&treeSeq, filename.c_str(), 0)) {
         throw TskitApiFailure("Failed to load treeseq file");
     }
 
-    return grgl::convertTreeSeqToGRG(&treeSeq, binaryMutations);
+    return grgl::convertTreeSeqToGRG(&treeSeq, binaryMutations, useNodeTimes, maintainTopology, computeCoals);
 }
 
 } // namespace grgl

--- a/src/grgl.cpp
+++ b/src/grgl.cpp
@@ -111,6 +111,9 @@ int main(int argc, char** argv) {
         "maintain-topo",
         "When converting tree-seq, maintain all topology below mutations (at the cost of a larger graph)",
         {"maintain-topo"});
+    args::Flag tsComputeCoals(
+        parser, "ts-coals", "When converting tree-seq, compute node individual coalescences.", {"ts-coals"});
+
     args::ValueFlag<std::string> populationIds(parser,
                                                "population-ids",
                                                "Format: \"filename:fieldname\". Read population ids from the given "
@@ -202,7 +205,7 @@ int main(int argc, char** argv) {
         TSKIT_OK_OR_EXIT(tsk_treeseq_load(&treeSeq, infile->c_str(), 0), "Failed to load tree-seq");
 
         try {
-            theGRG = grgl::convertTreeSeqToGRG(&treeSeq, binaryMutations, tsNodeTimes, maintainTopo);
+            theGRG = grgl::convertTreeSeqToGRG(&treeSeq, binaryMutations, tsNodeTimes, maintainTopo, tsComputeCoals);
         } catch (grgl::TskitApiFailure& e) {
             std::cerr << e.what();
             return 2;

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -443,13 +443,31 @@ PYBIND11_MODULE(_grgl, m) {
         :type bp_range: Tuple[int, int]
     )^");
 
-    m.def("grg_from_trees", &grgl::grgFromTrees, py::arg("filename"), py::arg("binary_mutations") = false, R"^(
+    m.def("grg_from_trees",
+          &grgl::grgFromTrees,
+          py::arg("filename"),
+          py::arg("binary_mutations") = false,
+          py::arg("use_node_times") = false,
+          py::arg("maintain_topology") = false,
+          py::arg("compute_coals") = false,
+          R"^(
         Convert a .trees (TSKit tree-sequence) file to a GRG.
 
         :param filename: The tree-sequence (.trees) file to load.
         :type filename: str
         :param binary_mutations: Set to True to flatten all mutations to be bi-allelic (optional).
         :type binary_mutations: bool
+        :param use_node_times: Mutations will be assigned the time from the node below them, instead of
+            the tskit Mutation object.
+        :type use_node_times: bool
+        :param maintain_topology: Generates a slightly larger GRG, but ensures that we capture all tree
+            topology changes induced by recombination, not just the changes that result in a different
+            set of samples beneath a node.
+        :type maintain_topology: bool
+        :param compute_coals: Compute the per-node coalescence counts. I.e., how many individuals coalesced
+            exactly at the node (separate children have both haploid copies of the individual). This is an
+            expensive computation, slowing down the TS to GRG conversion when there are a lot of samples.
+        :type compute_coals: bool
         :return: The GRG.
         :rtype: pygrgl.GRG
     )^");


### PR DESCRIPTION
* Fairly efficient algorithm for counting the number of individuals that coalesce at each node, during the conversion from tree-seq to GRG. It "forgets" individual list information as quickly as possible in an effort to save RAM.
* Add some additional checks on the tree-sequence samples and individuals to make sure they conform to the GRG assumptions. We can theoretically handle tree-seqs where there are non-leaf samples, but only if those samples are parents of samples all the way down (e.g., the last "layer" of the trees is all samples). In the future we may want a way to flag non-leafy samples.
* Fix some issues with the allele freq output when there are multiple copies of the same mutation.