### PR TITLE
Ensure that assigning coalescence counts is done atomically

### DIFF
--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -406,6 +406,10 @@ public:
 
     /**
      * Set the number of individuals that coalesce at this node.
+     *
+     * The value is updated atomically, so this can be used from threaded code (as long
+     * as the rest of the GRG, e.g. number of nodes, is not changing).
+     *
      * @param[in] nodeId The node to modify.
      * @param[in] coals The number of individuals that coalesce, between 0...numSamples()/ploidy.
      */
@@ -514,6 +518,9 @@ public:
         }
         if (!forceOrdered) {
             this->m_nodesAreOrdered = false;
+        }
+        if (this->m_nodes.size() > this->m_numSamples) {
+            this->m_nodeData.allocNumCoals((this->m_nodes.size() - this->m_numSamples) + 1);
         }
         return nextId;
     }

--- a/include/grgl/node_data.h
+++ b/include/grgl/node_data.h
@@ -52,21 +52,23 @@ public:
         }
         const NodeID index = nodeId - numSamples;
         if (index < m_nodeData_numCoals.size()) {
-            const auto& coalCount = m_nodeData_numCoals[index];
+            const auto coalCount = m_nodeData_numCoals.read_atomic(index);
             assert(coalCount == COAL_COUNT_NOT_SET || coalCount < numSamples);
             return coalCount;
         }
         return COAL_COUNT_NOT_SET;
     }
 
+    void allocNumCoals(const NodeIDSizeT nonSampleNodes) {
+        m_nodeData_numCoals.resize(nonSampleNodes, COAL_COUNT_NOT_SET);
+    }
+
     void setNumCoals(const NodeIDSizeT numSamples, NodeID nodeId, NodeIDSizeT coalCount) {
         if (nodeId >= numSamples) {
             const NodeID index = nodeId - numSamples;
-            if (index >= m_nodeData_numCoals.size()) {
-                m_nodeData_numCoals.resize(index + 1, COAL_COUNT_NOT_SET);
-            }
+            release_assert(index < m_nodeData_numCoals.size());
             assert(coalCount == COAL_COUNT_NOT_SET || coalCount < numSamples);
-            m_nodeData_numCoals.ref(index) = coalCount;
+            m_nodeData_numCoals.store_atomic(index, coalCount);
         }
     }
 

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -251,6 +251,8 @@ public:
                         m_edgeCSR.flushBuckets(m_outStream);
                         assert_deserialization(m_outStream.good(), "Writing GRG failed");
                     }
+                    release_assert(newNodeId >= m_newSampleCount);
+                    m_newNodeData.allocNumCoals((newNodeId - m_newSampleCount) + 1);
                     m_newNodeData.setNumCoals(m_newSampleCount, newNodeId, parentCoals);
                 } else {
                     m_nodeIdMap[nodeId] = INVALID_NODE_ID;


### PR DESCRIPTION
MapMutations traversal can be done in an immutable way, except for assigning coalescence counts. The actual adding of the mutation nodes/edges of course mutates the graph, but the rest of the algorithm does not.