### PR TITLE
shared_frontier() API, matmul(emit_all_nodes=True), improve topo

### DIFF
--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -4,7 +4,7 @@ Python API
 ----------
 
 .. automodule:: pygrgl
-    :members: grg_to_cyto_json, load_mutable_grg, load_immutable_grg, save_grg, save_subset, grg_from_trees, get_bfs_order, get_dfs_order, get_topo_order, dot_product, matmul, INVALID_NODE, COAL_COUNT_NOT_SET, GRG_FILE_VERSION
+    :members: grg_to_cyto_json, load_mutable_grg, load_immutable_grg, save_grg, save_subset, grg_from_trees, get_bfs_order, get_dfs_order, get_topo_order, dot_product, matmul, shared_frontier, INVALID_NODE, COAL_COUNT_NOT_SET, GRG_FILE_VERSION
 
 .. automodule:: pygrgl.display
     :members: grg_to_cyto

--- a/include/grgl/grgnode.h
+++ b/include/grgl/grgnode.h
@@ -51,10 +51,10 @@ using NodeID = uint32_t;
 using NodeIDSizeT = uint32_t;
 
 // We support about 2 billion nodes per graph.
-#define MAX_GRG_NODES   (0x7fffffffU - 1)
-#define INVALID_NODE_ID (0x7fffffffU)
+static constexpr NodeIDSizeT MAX_GRG_NODES = 0x7fffffffU - 1;
+static constexpr NodeID INVALID_NODE_ID = 0x7fffffffU;
 // The upper bit is available for flags.
-#define GRG_NODE_FLAG_MASK (0x80000000U)
+static constexpr NodeID GRG_NODE_FLAG_MASK = 0x80000000U;
 
 using NodeMark = NodeID;
 constexpr NodeMark NODE_MARK_1 = 0x80000000U;


### PR DESCRIPTION
* New Python API `shared_frontier()` traverses in a direction from a given list of seed nodes and collects any nodes that are reachable from all seeds on the current path. All paths are searched. If a path has no nodes that are shared by all seeds, then no nodes from that path will be output in the frontier. Useful for queries of small sets of (highly similar) nodes, as it can be on the order of microseconds instead of milliseconds for the equivalent use-case with `matmul()`.
* `matmul()` has a new `emit_all_nodes` parameter, which when set will make the output rows be values for all nodes, instead of just the samples or mutations (depending on direction). The input is still a vector of sample/mutation values.
* Topological search now has a sparse and dense version. The sparse version is way faster when the search starts from just a few nodes and the dense version is way faster when the search starts from many nodes (especially if they are not "related"). Also, there was a minor performance bug on the dense topo search, where it wouldn't terminate as early as it could.