### PR TITLE
Add "-o" flag to "grg split"

### DIFF
--- a/doc/examples_and_applications.rst
+++ b/doc/examples_and_applications.rst
@@ -41,6 +41,33 @@ Usage examples can be found in the `example jupyter notebooks <https://github.co
 Splitting GRGs
 --------------
 
-See command ``grg split`` and Python API :py:meth:`save_subset`.
+See command ``grg split --help`` and Python API :py:meth:`save_subset`.
 
-**TODO: Expand description.**
+Splitting equally
+~~~~~~~~~~~~~~~~~
+
+You can use ``grg split input.grg -s <size in base-pair>`` to split a GRG into equal graphs, each of which cover
+a base-pair range as specified by the ``-s`` flag. If you specify the ``--rec-map <hapmap-style file>`` option,
+the size is assumed to be in centimorgans (cM).
+
+If you have a list of ranges that you want to split a GRG into, you can put them in a text file with two columns
+(space separated) and a header line. Here is an example file:
+
+::
+
+  start end
+  0     1000000
+  1000000 2000000
+  5000000 7000000
+
+Then save that file (e.g., as ``ranges.txt``) and pass it to the split command like: ``grg split input.grg -f ranges.txt``.
+This will create 3 GRG files, each spanning one of the ranges from the text file. These ranges are inclusive on "start"
+and exlusive on "end", so to get full coverage of the genome you want each consecutive range to have a "start" that is
+identical to the previous range's "end".
+
+By default, for a file ``input.grg`` the split command will produce a directory ``input.grg.split/`` and place all the
+resulting split GRGs in that directory. You can change the directory using the ``-o`` flag, like:
+``grg split input.grg -s 1000000 -o my_split_grgs``.
+
+The output directory must not already exist, or splitting will fail and ask you to remove the directory or
+specify a different one.

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -166,7 +166,7 @@ public:
     std::pair<BpPosition, BpPosition> getBPRange() {
         if (mutationsAreOrdered() && !m_mutations.empty()) {
             const size_t lastMutId = m_mutations.size() - 1;
-            return {m_mutations[0].getPosition(), m_mutations[lastMutId].getPosition()+1};
+            return {m_mutations[0].getPosition(), m_mutations[lastMutId].getPosition() + 1};
         }
         BpPosition firstPos = std::numeric_limits<BpPosition>::max();
         BpPosition lastPos = 0;

--- a/pygrgl/clicmd/split.py
+++ b/pygrgl/clicmd/split.py
@@ -19,10 +19,19 @@ import subprocess
 
 def add_options(subparser):
     subparser.add_argument("input_file", help="The input GRG file")
-    subparser.add_argument(
-        "size_per_grg",
+    input_group = subparser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument(
+        "--size-per-grg",
+        "-s",
         type=float,
         help="The amount of BP or cM per GRG. If --rec-map is specified then this is cM, otherwise BP",
+    )
+    input_group.add_argument(
+        "--range-file",
+        "-f",
+        help='The text file containing two columns, labeled "start" and "end", where each column is '
+        'space separated. Each row after the header contains a "lower upper" pair specifying a range to '
+        "create a GRG for. If --rec-map is specified then the positions are cM, otherwise BP",
     )
     subparser.add_argument(
         "--jobs",
@@ -51,7 +60,11 @@ grgl_exe = which("grgl")
 def do_split(args):
     if grgl_exe is None:
         raise RuntimeError("Could not find 'grgl' executable; please add to your PATH")
-    split_arg = f"{args.size_per_grg}"
+    if args.size_per_grg is not None:
+        split_arg = f"{args.size_per_grg}"
+    else:
+        assert args.range_file is not None
+        split_arg = f"{args.range_file}"
     if args.rec_map is not None:
         split_arg = f"{args.rec_map}:{split_arg}"
     cmd = [grgl_exe, args.input_file, "--split", split_arg, "-j", str(args.jobs)]

--- a/pygrgl/clicmd/split.py
+++ b/pygrgl/clicmd/split.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # with this program.  If not, see <https://www.gnu.org/licenses/>.
 from .common import which, time_call
+import subprocess
 
 
 def add_options(subparser):
@@ -36,6 +37,12 @@ def add_options(subparser):
         default=None,
         help="Use the given HapMap-style recombination map and interpret the size_per_grg as cM.",
     )
+    subparser.add_argument(
+        "--outdir",
+        "-o",
+        default=None,
+        help="Create this directory and place the split GRGs into it.",
+    )
 
 
 grgl_exe = which("grgl")
@@ -48,4 +55,10 @@ def do_split(args):
     if args.rec_map is not None:
         split_arg = f"{args.rec_map}:{split_arg}"
     cmd = [grgl_exe, args.input_file, "--split", split_arg, "-j", str(args.jobs)]
-    time_call(cmd)
+    if args.outdir is not None:
+        cmd.extend(["-o", args.outdir])
+    try:
+        print(cmd)
+        time_call(cmd)
+    except subprocess.CalledProcessError as e:
+        print(f"Splitting failed with return code {e.returncode}")

--- a/src/grgl.cpp
+++ b/src/grgl.cpp
@@ -16,7 +16,9 @@
  */
 #include <args.hxx>
 #include <chrono>
+#include <exception>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <tskit.h>
@@ -122,9 +124,13 @@ int main(int argc, char** argv) {
     args::ValueFlag<std::string> windowedSplit(
         parser,
         "windowedSplit",
-        "Split graph into this many GRGs with the given number of BP or cM per GRG. Argument is either BP or cM "
-        "(integer/double), prefixed by a hapmap-style recombination map filename (e.g. \"filename:integer\")"
-        " when the value is cM. Creates a directory <infile>.split/ and puts all the resulting GRGs there.",
+        "Split input graph into multiple output graphs. Use --outfile to specify a directory to be created "
+        "that will hold the output GRG files. There are two ways to specify splitting the input graph: "
+        "(1) a single number means split into GRGs where each covers the given number of BP or cM. "
+        "(2) a filename containing a list of ranges, one per line, where each range is \"lower upper\" in "
+        " either BP or cM (depends on whether a recombination map was specified)"
+        "If the option is prefixed by a hapmap-style recombination map filename (e.g. \"filename:value\")"
+        " then all positions will be interpreted as cM instead of base pair.",
         {"split"});
     args::ValueFlag<size_t> jobsArg(
         parser,
@@ -291,20 +297,63 @@ int main(int argc, char** argv) {
             std::cerr << "Invalid split argument: \"" << *windowedSplit << "\"" << std::endl;
             return 2;
         }
-        double perWindowAmt = 0;
-        if (!parseExactDouble(tokens[tokens.size() - 1], perWindowAmt)) {
-            std::cerr << "Invalid split argument: \"" << *windowedSplit << "\"" << std::endl;
-            return 2;
-        }
 
         const size_t jobs = jobsArg ? *jobsArg : 1;
-        const size_t overlap = 1; // TODO: add support for overlapping windows.
         grgl::WindowList windows;
-        if (mapFile.empty()) {
-            windows = grgl::windowByBP(theGRG->getBPRange(), (size_t)perWindowAmt, 1);
+        double perWindowAmt = 0;
+        const std::string& argValue = tokens[tokens.size() - 1];
+        if (!parseExactDouble(argValue, perWindowAmt)) {
+            if (pathExists(argValue)) {
+                std::vector<std::pair<std::string, std::string>> rangeStrings;
+                try {
+                    rangeStrings =
+                        loadMapFromTSV<std::vector<std::pair<std::string, std::string>>>(argValue, "start", "end", ' ');
+                } catch (const std::exception& e) {
+                    std::cerr << "Failed to properly read file " << argValue << ": " << e.what() << std::endl;
+                    return 2;
+                }
+                if (!mapFile.empty()) {
+                    throw std::runtime_error("TODO: Implement range file support with cM (recombination map)");
+                }
+                for (size_t i = 0; i < rangeStrings.size(); i++) {
+                    const auto& pair = rangeStrings[i];
+                    bool success = true;
+                    if (mapFile.empty()) {
+                        uint64_t lower = 0;
+                        uint64_t upper = 0;
+                        success &= (bool)parseExactUint64(pair.first, lower);
+                        success &= (bool)parseExactUint64(pair.second, upper);
+                        windows.push_back({lower, upper});
+                    } else {
+                        double lower = 0.0;
+                        double upper = 0.0;
+                        success &= (bool)parseExactDouble(pair.first, lower);
+                        success &= (bool)parseExactDouble(pair.second, upper);
+                        // TODO: map these to base-pair positions via the recombination map.
+                    }
+                    if (!success) {
+                        std::cerr << "Invalid number at line " << i + 2 << " of file " << argValue << std::endl;
+                        return 2;
+                    }
+                }
+                if (rangeStrings.empty()) {
+                    std::cerr << "No range data in file " << argValue << std::endl;
+                    return 2;
+                }
+            } else {
+                std::cerr << "Bad split value: \"" << argValue << "\": invalid number and/or filename" << std::endl;
+                return 2;
+            }
         } else {
-            windows = grgl::windowByCM(theGRG->getBPRange(), mapFile, perWindowAmt, 1);
+            const size_t overlap = 1; // TODO: add support for overlapping windows.
+            release_assert(perWindowAmt > 0);
+            if (mapFile.empty()) {
+                windows = grgl::windowByBP(theGRG->getBPRange(), (size_t)perWindowAmt, 1);
+            } else {
+                windows = grgl::windowByCM(theGRG->getBPRange(), mapFile, perWindowAmt, 1);
+            }
         }
+        release_assert(!windows.empty());
 
         // Worker pool for splitting the GRG.
         class SplitJobs : public grgl::PooledJobs<grgl::Window> {

--- a/src/grgl.cpp
+++ b/src/grgl.cpp
@@ -266,21 +266,16 @@ int main(int argc, char** argv) {
         dumpStats(theGRG);
     }
 
-    if (outfile) {
-        START_TIMING_OPERATION();
-        auto counts = saveGRG(theGRG, *outfile, !noSimplify);
-        std::cout << "Wrote simplified GRG with:" << std::endl;
-        std::cout << "  Nodes: " << counts.first << std::endl;
-        std::cout << "  Edges: " << counts.second << std::endl;
-
-        EMIT_TIMING_MESSAGE("Wrote GRG to " << *outfile << " in ");
-    }
-
     if (windowedSplit) {
         std::stringstream splitOutPrefix;
-        splitOutPrefix << *infile << ".split";
+        if (outfile) {
+            splitOutPrefix << *outfile;
+        } else {
+            splitOutPrefix << *infile << ".split";
+        }
         if (pathExists(splitOutPrefix.str())) {
-            std::cerr << "Split output directory " << splitOutPrefix.str() << " already exists; remove and try again"
+            std::cerr << "Split output directory " << splitOutPrefix.str()
+                      << " already exists; remove and try again (or specify a different directory to create)"
                       << std::endl;
             return 2;
         }
@@ -340,6 +335,15 @@ int main(int argc, char** argv) {
         }
         workers.doAllWork(jobs);
         EMIT_TIMING_MESSAGE("Split GRG into " << windows.size() << " parts in ");
+    } else if (outfile) {
+        START_TIMING_OPERATION();
+        auto counts = saveGRG(theGRG, *outfile, !noSimplify);
+        std::cout << "Wrote simplified GRG with:" << std::endl;
+        std::cout << "  Nodes: " << counts.first << std::endl;
+        std::cout << "  Edges: " << counts.second << std::endl;
+
+        EMIT_TIMING_MESSAGE("Wrote GRG to " << *outfile << " in ");
     }
+
     return 0;
 }

--- a/src/grgl.cpp
+++ b/src/grgl.cpp
@@ -313,6 +313,7 @@ int main(int argc, char** argv) {
                     return 2;
                 }
                 if (!mapFile.empty()) {
+                    std::cerr << "TODO: Implement range file support with cM (recombination map)" << std::endl;
                     throw std::runtime_error("TODO: Implement range file support with cM (recombination map)");
                 }
                 for (size_t i = 0; i < rangeStrings.size(); i++) {

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -721,11 +721,11 @@ PYBIND11_MODULE(_grgl, m) {
         :param emit_all_nodes: False by default. Set to True if you want each output row in the matrix to
             have a value for every node, not just every sample/mutation (depending on direction).
         :type emit_all_nodes: bool
-        :param byIndividual: The dimension that is for samples (either the input or output, depending on the
+        :param by_individual: The dimension that is for samples (either the input or output, depending on the
             direction parameter) uses individuals instead of haploid samples. Instead of outputting vectors
             of :math:`N` (:py:attr:`num_samples`) columns, it is :math:`N / ploidy` (:py:attr:`num_individuals`)
             columns.
-        :type byIndividual: bool
+        :type by_individual: bool
         :return: The numpy 2-dimensional array of output values.
         :rtype: numpy.array
     )^");

--- a/src/util.h
+++ b/src/util.h
@@ -174,7 +174,10 @@ inline void helper_addToStringMap(std::vector<std::pair<std::string, std::string
  * Helper to convert data from a tab-separate file into a string->string map.
  */
 template <typename MapType = std::map<std::string, std::string>>
-inline MapType loadMapFromTSV(const std::string& filename, const std::string& lhsField, const std::string& rhsField) {
+inline MapType loadMapFromTSV(const std::string& filename,
+                              const std::string& lhsField,
+                              const std::string& rhsField,
+                              const char separator = '\t') {
     release_assert(lhsField != rhsField);
     std::ifstream infile(filename);
     if (!infile) {
@@ -189,7 +192,7 @@ inline MapType loadMapFromTSV(const std::string& filename, const std::string& lh
     size_t rhsIndex = std::numeric_limits<size_t>::max();
     MapType result;
     while (std::getline(infile, line)) {
-        auto tokens = split(line, '\t');
+        auto tokens = split(line, separator);
         if (lineNum == 0) {
             numCols = tokens.size();
             for (size_t i = 0; i < tokens.size(); i++) {

--- a/test/endtoend/test_basic.py
+++ b/test/endtoend/test_basic.py
@@ -102,7 +102,7 @@ class TestGrgConstruction(unittest.TestCase):
 
         # Split the GRG
         subprocess.check_output(
-            ["grg", "split", "-j", str(4), grg_filename, str(100000)]
+            ["grg", "split", "-j", str(4), grg_filename, "-s", str(100000)]
         )
         saw_freqs = {}
         for grg_part in glob.glob(f"{split_dir}/*.grg"):


### PR DESCRIPTION
`grg split` changes:
* Can specify what directory to put the resulting split GRGs into.
* Can specify  a number of arbitrary ranges to split with. Right now has to be base-pair coordinates (cM is unimplemented).