### PR TITLE
GRG file format: add individual ID support

### DIFF
--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -13,7 +13,7 @@ Python API
     :members: __init__, position, allele, ref_allele, time
 
 .. autoclass:: pygrgl.GRG
-    :members: is_sample, num_samples, num_individuals, ploidy, bp_range, specified_bp_range, nodes_are_ordered, mutations_are_ordered, num_nodes, num_edges, num_up_edges, num_down_edges, get_down_edges, get_up_edges, get_sample_nodes, get_root_nodes, get_node_mutation_pairs, get_mutation_node_pairs, get_mutations_for_node, get_mutation_by_id, set_mutation_by_id, node_has_mutations, add_population, get_populations, add_mutation, num_mutations, get_population_id, set_population_id, get_num_individual_coals, set_num_individual_coals
+    :members: is_sample, num_samples, num_individuals, ploidy, bp_range, specified_bp_range, nodes_are_ordered, mutations_are_ordered, num_nodes, num_edges, num_up_edges, num_down_edges, get_down_edges, get_up_edges, get_sample_nodes, get_root_nodes, get_node_mutation_pairs, get_mutation_node_pairs, get_mutations_for_node, get_mutation_by_id, set_mutation_by_id, node_has_mutations, add_population, get_populations, add_mutation, num_mutations, get_population_id, set_population_id, get_num_individual_coals, set_num_individual_coals, has_individual_ids, clear_individual_ids, add_individual_id, get_individual_id
 
 .. autoclass:: pygrgl.MutableGRG
     :members: make_node, connect, disconnect, merge

--- a/include/grgl/common.h
+++ b/include/grgl/common.h
@@ -132,9 +132,12 @@ inline std::size_t hash_combine(std::size_t hash1, std::size_t hash2) {
     return hash1 ^ (hash2 + 0x9e3779b9 + (hash1 << 6U) + (hash1 >> 2U));
 }
 
+// Optional: set if the GRG has individual IDs, otherwise it is unset.
+constexpr uint64_t GRG_FLAG_HAS_INDIV_IDS = 0x1;
+
 constexpr uint64_t GRG_FILE_MAGIC = 0xE9366C64DDC8C5B0;
 constexpr uint16_t GRG_FILE_MAJOR_VERSION = 5;
-constexpr uint16_t GRG_FILE_MINOR_VERSION = 0;
+constexpr uint16_t GRG_FILE_MINOR_VERSION = 1;
 
 #pragma pack(push, 1)
 struct GRGFileHeader {

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <vector>
 
+#include "file_vector.h"
 #include "grgl/common.h"
 #include "grgl/csr_storage.h"
 #include "grgl/file_vector.h"
@@ -66,6 +67,12 @@ public:
     NodeIDList seedList;
     std::pair<BpPosition, BpPosition> bpRange;
 };
+
+// A string table is just a bunch of unencoded, unsorted characters. The CSR index lets us
+// get the i'th string efficiently. For very short strings (a few characters) this is not worth
+// the storage, because each index takes 4 bytes. For any string that is variable length and
+// expected to be more than 4 characters, this is a great representation.
+using CSRStringTable = CSRStorageImm<EagerFileVector, uint8_t, false, false>;
 
 /**
  * Abstract GRG base class.
@@ -451,6 +458,46 @@ public:
         m_nodeData.setNumCoals(numSamples(), nodeId, coals);
     }
 
+    /**
+     * Add the next individual's identifier. Must be called in order, for individuals
+     * 0...(N-1).
+     *
+     * @param identifier The identifier to add.
+     */
+    void addIndividualId(const std::string& identifier) {
+        if (m_individualIds.numNodes() == 0) {
+            m_individualIds = CSRStringTable(this->numIndividuals());
+        }
+        m_individualIds.appendData(reinterpret_cast<const uint8_t*>(identifier.c_str()), identifier.size());
+    }
+
+    /**
+     * Clear all individual identifiers.
+     */
+    void clearIndividualIds() { m_individualIds = CSRStringTable(); }
+
+    /**
+     * Are there any string identifiers for the individuals in this GRG?
+     *
+     * @return true if individual identifiers are available.
+     */
+    bool hasIndividualIds() const { return m_individualIds.numNodes() > 0; }
+
+    /**
+     * Get the string identifier for the k'th individual. Returns empty string if there is no identifier
+     * for the given individual.
+     *
+     * @return String identifier for the given individual.
+     */
+    std::string getIndividualId(NodeIDSizeT individualIndex) {
+        if (!hasIndividualIds()) {
+            throw ApiMisuseFailure("No individual IDs on this GRG; check hasIndividualIds()");
+        }
+        std::vector<uint8_t> characters;
+        m_individualIds.getData(individualIndex, characters);
+        return {reinterpret_cast<const char*>(characters.data()), characters.size()};
+    }
+
 protected:
     void visitTopoNodeOrderedDense(GRGVisitor& visitor, TraversalDirection direction, const NodeIDList& seedList);
     void visitTopoNodeOrderedSparse(GRGVisitor& visitor, TraversalDirection direction, const NodeIDList& seedList);
@@ -479,6 +526,9 @@ protected:
     // Node data.
     NodeDataContainer m_nodeData;
 
+    // Sample (individual) identifiers
+    CSRStringTable m_individualIds;
+
     const size_t m_numSamples;
     const uint16_t m_ploidy;
 
@@ -486,6 +536,8 @@ protected:
     bool m_mutsAreOrdered{false};
 
     friend void readGrgCommon(const GRGFileHeader& header, const GRGPtr& grg, IFSPointer& inStream);
+    friend std::pair<NodeIDSizeT, size_t>
+    simplifyAndSerialize(const GRGPtr& grg, std::ostream& outStream, const GRGOutputFilter& filter, bool allowSimplify);
 
     // Google-test unit tests that need private/protected access.
     FRIEND_TEST(GRG, TestTopoVisit);

--- a/pygrgl/clicmd/construct.py
+++ b/pygrgl/clicmd/construct.py
@@ -108,6 +108,11 @@ def add_options(subparser):
         action="store_true",
         help='Do not merge the resulting GRGs (so if you specified "-p C" there will be C GRGs).',
     )
+    subparser.add_argument(
+        "--no-indiv-ids",
+        action="store_true",
+        help="Do not storage individual string identifiers in the GRG.",
+    )
 
 
 grgl_exe = which("grgl")
@@ -144,6 +149,8 @@ def build_shape(range_triple, args, input_file):
             command.extend(["--population-ids", args.population_ids])
         if args.bs_triplet:
             command.extend(["--bs-triplet", args.bs_triplet])
+        if args.no_indiv_ids:
+            command.append("--no-indiv-ids")
         command.extend(["--lf-filter", str(args.shape_lf_filter)])
         command.extend(
             [

--- a/scripts/add_indiv_ids.py
+++ b/scripts/add_indiv_ids.py
@@ -1,0 +1,27 @@
+# Add Individual IDs to an existing GRG that does not have them.
+# IDs are provided via a text file, with a single line per ID.
+import pygrgl
+import sys
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: add_indiv_ids.py <GRG filename> <ID text filename>", file=sys.stderr)
+        exit(1)
+
+    identifiers = []
+    with open(sys.argv[2]) as f:
+        for line in f:
+            identifiers.append(line.strip())
+    
+    GRG = sys.argv[1]
+    assert GRG.endswith(".grg"), "The GRG file must end with .grg"
+    prefix = GRG[:-4]
+
+    grg = pygrgl.load_immutable_grg(GRG)
+    assert not grg.has_individual_ids, f"Provided GRG already has individual identifiers"
+    assert grg.num_individuals == len(identifiers), f"GRG has {grg.num_individuals} individuals, but the ID text file has {len(identifiers)} lines"
+
+    for ident in identifiers:
+        grg.add_individual_id(ident)
+    pygrgl.save_grg(grg, f"{prefix}.WITHIDS.grg")
+    print(f"Saved result to {prefix}.WITHIDS.grg")

--- a/src/build_shape.h
+++ b/src/build_shape.h
@@ -29,6 +29,15 @@ namespace grgl {
 class MutableGRG;
 using MutableGRGPtr = std::shared_ptr<MutableGRG>;
 
+enum {
+    GBF_USE_BINARY_MUTS = 0x1U,
+    GBF_EMIT_MISSING_DATA = 0x2U,
+    GBF_FLIP_REF_MAJOR = 0x4U,
+    GBF_NO_INDIVIDUAL_IDS = 0x8U,
+    GBF_VERBOSE_OUTPUT = 0x10U,
+};
+using GrgBuildFlags = uint64_t;
+
 /**
  * Given a VCF file, and a genome range, construct a GRG for that range - but do not map the
  * mutations. The resulting graph just has empty nodes and sample nodes, and is connected.
@@ -36,9 +45,7 @@ using MutableGRGPtr = std::shared_ptr<MutableGRG>;
 MutableGRGPtr createEmptyGRGFromSamples(const std::string& sampleFile,
                                         FloatRange& genomeRange,
                                         size_t bitsPerMutation,
-                                        bool useBinaryMuts,
-                                        bool emitMissingData,
-                                        bool flipRefMajor,
+                                        GrgBuildFlags buildFlags,
                                         double dropBelowThreshold,
                                         const std::map<std::string, std::string>& indivIdToPop,
                                         size_t tripletLevels = 0);

--- a/src/grgl.cpp
+++ b/src/grgl.cpp
@@ -137,6 +137,8 @@ int main(int argc, char** argv) {
         "jobs",
         "Use this many threads for the given task. Currently only applies to the --split command",
         {'j', "jobs"});
+    args::Flag noIndividualIds(
+        parser, "no-indiv-ids", "Do not store individual string identifiers in the GRG", {"no-indiv-ids"});
     try {
         parser.ParseCLI(argc, argv);
     } catch (args::Help&) {
@@ -228,12 +230,23 @@ int main(int argc, char** argv) {
             return 2;
         }
     } else if (supportedInputFormat(*infile)) {
+        uint64_t buildFlags = grgl::GBF_VERBOSE_OUTPUT;
+        if (binaryMutations) {
+            buildFlags |= grgl::GBF_USE_BINARY_MUTS;
+        }
+        if (missingDataHandling == MDH_ADD_TO_GRG) {
+            buildFlags |= grgl::GBF_EMIT_MISSING_DATA;
+        }
+        if (MAFFlip) {
+            buildFlags |= grgl::GBF_FLIP_REF_MAJOR;
+        }
+        if (noIndividualIds) {
+            buildFlags |= grgl::GBF_NO_INDIVIDUAL_IDS;
+        }
         theGRG = grgl::createEmptyGRGFromSamples(*infile,
                                                  restrictRange,
                                                  bitsPerMutation,
-                                                 binaryMutations,
-                                                 missingDataHandling == MDH_ADD_TO_GRG,
-                                                 MAFFlip,
+                                                 buildFlags,
                                                  lfFilter ? *lfFilter : 0.0,
                                                  indivIdToPop,
                                                  triplet ? *triplet : 0);

--- a/src/mut_iterator.cpp
+++ b/src/mut_iterator.cpp
@@ -267,7 +267,7 @@ size_t IGDMutationIterator::countMutations() const {
     return mutations;
 }
 
-std::vector<std::string> IGDMutationIterator::getIndividualIds() { return m_igd->getIndividualIds(); }
+std::vector<std::string> IGDMutationIterator::getIndividualIds() { return std::move(m_igd->getIndividualIds()); }
 
 void IGDMutationIterator::buffer_next(size_t& totalSamples) {
     totalSamples = m_igd->numSamples();

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -433,6 +433,31 @@ PYBIND11_MODULE(_grgl, m) {
                 :type node_id: int
                 :param num_coals: The number of individuals that coalesced, or pygrgl.COAL_COUNT_NOT_SET.
                 :type num_coals: int
+            )^")
+        .def_property_readonly("has_individual_ids", &grgl::GRG::hasIndividualIds, R"^(
+            True if this GRG has string identifiers for each individual. See get_individual_id().
+            )^")
+        .def("clear_individual_ids", &grgl::GRG::clearIndividualIds, R"^(
+            Remove all individual IDs from the current GRG.
+            )^")
+        .def("add_individual_id", &grgl::GRG::addIndividualId, py::arg("identifier"), R"^(
+            Add the next string identifier for an individual in the dataset. If the individual IDs
+            are already set, this will throw an exception. This must be called in order, from the
+            0th to the (N-1)st individual.
+
+            :param identifier: The string identifier for the next individual.
+            :type identifier: str
+            )^")
+        .def("get_individual_id", &grgl::GRG::getIndividualId, py::arg("individual_index"), R"^(
+            Get the string identifiers for each of the N individuals in the dataset, if available.
+            These are optional, so the empty list will be returned if the GRG does not have them.
+            See has_individual_ids.
+
+            :param individual_index: The individual to retrieve. The individuals are numbered from
+                0...(num_individuals-1), and correspond to the sample NodeIDs divided by their ploidy.
+            :type individual_index: int
+            :return: String identifier for the given individual.
+            :rtype: str
             )^");
     grgClass.doc() = "A Genotype Representation Graph (GRG) representing a particular dataset. "
                      "This is the immutable portion of the API, so every graph has these operations. "

--- a/test/unit/test_construct.cpp
+++ b/test/unit/test_construct.cpp
@@ -47,7 +47,7 @@ TEST(Construct, WithPopIds) {
     // Test1: Incomplete individual -> population map
     indivIdToPop.emplace("Z1", "Population2");
     indivIdToPop.emplace("X1", "Population4");
-    EXPECT_THROW(createEmptyGRGFromSamples(filename, fullRange, 8, false, false, false, 0.0,
+    EXPECT_THROW(createEmptyGRGFromSamples(filename, fullRange, 8, 0x0U, 0.0,
                                            indivIdToPop), std::runtime_error);
 
     // Test2: Complete individual -> population map
@@ -56,7 +56,7 @@ TEST(Construct, WithPopIds) {
     indivIdToPop.emplace("B4", "Population3");
     indivIdToPop.emplace("A1", "Population1");
     indivIdToPop.emplace("X3", "Population4");
-    auto grg = createEmptyGRGFromSamples(filename, fullRange, 8, false, false, false, 0.0,
+    auto grg = createEmptyGRGFromSamples(filename, fullRange, 8, 0x0U, 0.0,
                                          indivIdToPop);
     ASSERT_EQ(grg->numSamples(), numIndividuals*2);
     auto popDescriptions = grg->getPopulations();


### PR DESCRIPTION
Identifiers for samples is useful for many popgen/statgen applications. They can optionally be stored in a GRG now. By default, if the input file contains them then the GRG will copy them during construction, unless the user specifies `--no-indiv-ids` to the `grg construct` command.

Identifiers can also be added to the GRG after the fact, see the example in scripts/add_indiv_ids.py

The backing for these IDs is a CSR array of characters, which is what most "data tables" that get added to the GRG file format should use going forward.