### PR TITLE
matmul() support for smaller datatypes, including bitvectors

### DIFF
--- a/include/grgl/common.h
+++ b/include/grgl/common.h
@@ -158,6 +158,10 @@ struct GRGFileHeader {
 #pragma pack(pop)
 static_assert(sizeof(GRGFileHeader) == 128, "GRG header size changed");
 
+template <typename T> inline T roundUpToMultiple(const T input, const T multiple) {
+    return ((input + (multiple - 1)) / multiple) * multiple;
+}
+
 } // namespace grgl
 
 #endif /* GRGL_COMMON_H */

--- a/include/grgl/internal_mult.h
+++ b/include/grgl/internal_mult.h
@@ -1,5 +1,10 @@
 
-template <typename T> inline void vectorAdd(T* vect1, const T* vect2, size_t count);
+template <typename T, bool useBitVector>
+inline void vectorAdd(T* vect1, const T* vect2, const size_t base1, const size_t base2, const size_t count);
+
+template <typename T, typename T2, bool useBitVector>
+inline void
+matmulPerformIOAddition(T* outputMatrix, const size_t outputIdx, const T2* inputMatrix, const size_t inputIdx);
 
 template <typename T> class ValueSumVisitor : public GRGVisitor {
 public:
@@ -16,12 +21,12 @@ public:
             if (direction == DIRECTION_DOWN) {
                 for (const auto& child : grg->getDownEdges(nodeId)) {
                     const size_t cbase = child * m_numRows;
-                    vectorAdd<T>(&m_nodeValues[base], &m_nodeValues[cbase], m_numRows);
+                    vectorAdd<T, false>(&m_nodeValues[0], &m_nodeValues[0], base, cbase, m_numRows);
                 }
             } else {
                 for (const auto& parent : grg->getUpEdges(nodeId)) {
                     const size_t pbase = parent * m_numRows;
-                    vectorAdd<T>(&m_nodeValues[base], &m_nodeValues[pbase], m_numRows);
+                    vectorAdd<T, false>(&m_nodeValues[0], &m_nodeValues[0], base, pbase, m_numRows);
                 }
             }
         }
@@ -33,78 +38,246 @@ private:
     const size_t m_numRows;
 };
 
-template <> inline void vectorAdd<double>(double* vect1, const double* vect2, const size_t count) {
-    size_t j = 0;
+// This showed no improvement in speed when using AVX, likely because of the time to load the
+// data to the special registers, and then we only do a single operation at a time. Probably
+// you have to do multiple operations to make it worthwhile.
+
+template <typename T> inline void valueWiseVectorAdd(T* vect1, const T* vect2, const size_t count) {
 #if USE_AVX
-    constexpr size_t batchSize = 4;
-    __m256d dst, src;
-    const size_t leftover = count & (batchSize - 1);
-    for (size_t i = 0; i + batchSize <= count; i += batchSize) {
-        dst = _mm256_loadu_pd(&vect1[i]);
-        src = _mm256_loadu_pd(&vect2[i]);
-        dst = _mm256_add_pd(dst, src);
-        _mm256_storeu_pd(&vect1[i], dst);
-    }
-    j = count - leftover;
+#error "Not implemented"
 #endif
-    for (; j < count; j++) {
+    for (size_t j = 0; j < count; j++) {
         vect1[j] += vect2[j];
     }
 }
 
-template <> inline void vectorAdd<float>(float* vect1, const float* vect2, const size_t count) {
+template <>
+inline void vectorAdd<double, false>(
+    double* vect1, const double* vect2, const size_t base1, const size_t base2, const size_t count) {
+    valueWiseVectorAdd(&vect1[base1], &vect2[base2], count);
+}
+
+template <>
+inline void
+vectorAdd<float, false>(float* vect1, const float* vect2, const size_t base1, const size_t base2, const size_t count) {
+    valueWiseVectorAdd(&vect1[base1], &vect2[base2], count);
+}
+
+template <>
+inline void vectorAdd<int64_t, false>(
+    int64_t* vect1, const int64_t* vect2, const size_t base1, const size_t base2, const size_t count) {
+    valueWiseVectorAdd(&vect1[base1], &vect2[base2], count);
+}
+
+template <>
+inline void vectorAdd<int32_t, false>(
+    int32_t* vect1, const int32_t* vect2, const size_t base1, const size_t base2, const size_t count) {
+    valueWiseVectorAdd(&vect1[base1], &vect2[base2], count);
+}
+
+template <>
+inline void vectorAdd<int16_t, false>(
+    int16_t* vect1, const int16_t* vect2, const size_t base1, const size_t base2, const size_t count) {
+    valueWiseVectorAdd(&vect1[base1], &vect2[base2], count);
+}
+
+template <>
+inline void vectorAdd<int8_t, false>(
+    int8_t* vect1, const int8_t* vect2, const size_t base1, const size_t base2, const size_t count) {
+    valueWiseVectorAdd(&vect1[base1], &vect2[base2], count);
+}
+
+template <>
+inline void vectorAdd<uint64_t, false>(
+    uint64_t* vect1, const uint64_t* vect2, const size_t base1, const size_t base2, const size_t count) {
+    valueWiseVectorAdd(&vect1[base1], &vect2[base2], count);
+}
+
+template <>
+inline void vectorAdd<uint32_t, false>(
+    uint32_t* vect1, const uint32_t* vect2, const size_t base1, const size_t base2, const size_t count) {
+    valueWiseVectorAdd(&vect1[base1], &vect2[base2], count);
+}
+
+template <>
+inline void vectorAdd<uint16_t, false>(
+    uint16_t* vect1, const uint16_t* vect2, const size_t base1, const size_t base2, const size_t count) {
+    valueWiseVectorAdd(&vect1[base1], &vect2[base2], count);
+}
+
+template <>
+inline void vectorAdd<uint8_t, false>(
+    uint8_t* vect1, const uint8_t* vect2, const size_t base1, const size_t base2, const size_t count) {
+    valueWiseVectorAdd(&vect1[base1], &vect2[base2], count);
+}
+
+template <>
+inline void vectorAdd<uint8_t, true>(
+    uint8_t* vect1, const uint8_t* vect2, const size_t base1, const size_t base2, const size_t count) {
+    constexpr size_t elemBits = sizeof(uint8_t) * 8;
+    // The two vectors have to be aligned to a byte. This means callers that make use of matMul() with bitvectors
+    // have to ensure this. This is currently only exposed via the Python API, which guarantees this by padding out
+    // the input array as needed.
+    const size_t elemCount = count / elemBits;
+    release_assert(count % elemBits == 0);
+    const size_t base1E = base1 / elemBits;
+    release_assert(base1 % elemBits == 0);
+    const size_t base2E = base2 / elemBits;
+    release_assert(base2 % elemBits == 0);
     size_t j = 0;
-#if USE_AVX
-    constexpr size_t batchSize = 8;
-    __m256 dst, src;
-    const size_t leftover = count & (batchSize - 1);
-    for (size_t i = 0; i + batchSize <= count; i += batchSize) {
-        dst = _mm256_loadu_ps(&vect1[i]);
-        src = _mm256_loadu_ps(&vect2[i]);
-        dst = _mm256_add_ps(dst, src);
-        _mm256_storeu_ps(&vect1[i], dst);
-    }
-    j = count - leftover;
-#endif
-    for (; j < count; j++) {
-        vect1[j] += vect2[j];
+    for (; j < elemCount; j++) {
+        vect1[base1E + j] ^= vect2[base2E + j];
     }
 }
 
-template <> inline void vectorAdd<int64_t>(int64_t* vect1, const int64_t* vect2, const size_t count) {
-    size_t j = 0;
-#if USE_AVX
-    constexpr size_t batchSize = 2;
-    __m128i dst, src;
-    const size_t leftover = count & (batchSize - 1);
-    for (size_t i = 0; i + batchSize <= count; i += batchSize) {
-        dst = _mm_loadu_si128((__m128i*)&vect1[i]);
-        src = _mm_loadu_si128((__m128i*)&vect2[i]);
-        dst = _mm_add_epi64(dst, src);
-        _mm_storeu_si128((__m128i*)&vect1[i], dst);
+inline void validateMatMulInputs(const GRG* grg,
+                                 const size_t inputCols,
+                                 const size_t inputRows,
+                                 const TraversalDirection direction,
+                                 const size_t outputSize,
+                                 const bool emitAllNodes,
+                                 const bool byIndividual,
+                                 const size_t outputCols) {
+    release_assert(outputSize % inputRows == 0);
+    const size_t expectSampleCols = byIndividual ? grg->numIndividuals() : grg->numSamples();
+    if (direction == DIRECTION_DOWN) {
+        if (inputCols != grg->numMutations()) {
+            throw ApiMisuseFailure("Input vector is not size M (numMutations)");
+        }
+        if (!emitAllNodes && outputCols != expectSampleCols) {
+            throw ApiMisuseFailure("Output vector is not size N (numSamples, or numIndividuals depending on flags)");
+        }
+    } else {
+        if (inputCols != expectSampleCols) {
+            throw ApiMisuseFailure("Input vector is not size N (numSamples, or numIndividuals depending on flags)");
+        }
+        if (!emitAllNodes && outputCols != grg->numMutations()) {
+            throw ApiMisuseFailure("Output vector is not size M (numMutations)");
+        }
     }
-    j = count - leftover;
-#endif
-    for (; j < count; j++) {
-        vect1[j] += vect2[j];
+    if (emitAllNodes && outputCols != grg->numNodes()) {
+        throw ApiMisuseFailure("Output vector is not size numNodes");
     }
 }
 
-template <> inline void vectorAdd<int32_t>(int32_t* vect1, const int32_t* vect2, const size_t count) {
-    size_t j = 0;
-#if USE_AVX
-    constexpr size_t batchSize = 4;
-    __m128i dst1, src1;
-    const size_t leftover = count & (batchSize - 1);
-    for (size_t i = 0; i + batchSize <= count; i += batchSize) {
-        dst1 = _mm_loadu_si128((__m128i*)&vect1[i]);
-        src1 = _mm_loadu_si128((__m128i*)&vect2[i]);
-        dst1 = _mm_add_epi32(dst1, src1);
-        _mm_storeu_si128((__m128i*)&vect1[i], dst1);
+template <typename T>
+inline void
+matmulPerformIOAdditionHelper(T* outputMatrix, const size_t outputIdx, const T* inputMatrix, const size_t inputIdx) {
+    outputMatrix[outputIdx] += inputMatrix[inputIdx];
+}
+
+template <>
+inline void matmulPerformIOAddition<double, double, false>(double* outputMatrix,
+                                                           const size_t outputIdx,
+                                                           const double* inputMatrix,
+                                                           const size_t inputIdx) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
+}
+
+template <>
+inline void matmulPerformIOAddition<float, float, false>(float* outputMatrix,
+                                                         const size_t outputIdx,
+                                                         const float* inputMatrix,
+                                                         const size_t inputIdx) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
+}
+
+template <>
+inline void matmulPerformIOAddition<int64_t, int64_t, false>(int64_t* outputMatrix,
+                                                             const size_t outputIdx,
+                                                             const int64_t* inputMatrix,
+                                                             const size_t inputIdx) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
+}
+
+template <>
+inline void matmulPerformIOAddition<int32_t, int32_t, false>(int32_t* outputMatrix,
+                                                             const size_t outputIdx,
+                                                             const int32_t* inputMatrix,
+                                                             const size_t inputIdx) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
+}
+
+template <>
+inline void matmulPerformIOAddition<int16_t, int16_t, false>(int16_t* outputMatrix,
+                                                             const size_t outputIdx,
+                                                             const int16_t* inputMatrix,
+                                                             const size_t inputIdx) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
+}
+
+template <>
+inline void matmulPerformIOAddition<int8_t, int8_t, false>(int8_t* outputMatrix,
+                                                           const size_t outputIdx,
+                                                           const int8_t* inputMatrix,
+                                                           const size_t inputIdx) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
+}
+
+template <>
+inline void matmulPerformIOAddition<uint64_t, uint64_t, false>(uint64_t* outputMatrix,
+                                                               const size_t outputIdx,
+                                                               const uint64_t* inputMatrix,
+                                                               const size_t inputIdx) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
+}
+
+template <>
+inline void matmulPerformIOAddition<uint32_t, uint32_t, false>(uint32_t* outputMatrix,
+                                                               const size_t outputIdx,
+                                                               const uint32_t* inputMatrix,
+                                                               const size_t inputIdx) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
+}
+
+template <>
+inline void matmulPerformIOAddition<uint16_t, uint16_t, false>(uint16_t* outputMatrix,
+                                                               const size_t outputIdx,
+                                                               const uint16_t* inputMatrix,
+                                                               const size_t inputIdx) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
+}
+
+template <>
+inline void matmulPerformIOAddition<uint8_t, uint8_t, false>(uint8_t* outputMatrix,
+                                                             const size_t outputIdx,
+                                                             const uint8_t* inputMatrix,
+                                                             const size_t inputIdx) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
+}
+
+// If the input bit is 0, leave output unchanged. If the input bit is 1, flip the output
+// value to the other value.
+template <typename T> inline void matmulFlipSingleBit(T* outputMatrix, const size_t outputIdx) {
+    constexpr size_t elemBits = sizeof(T) * 8;
+    const size_t elemOffset = outputIdx / elemBits;
+    const size_t bitOffset = outputIdx % elemBits;
+    const T mask = 0x1U << bitOffset;
+    outputMatrix[elemOffset] ^= mask;
+}
+
+template <typename T> inline bool matmulGetSingleBit(const T* inputMatrix, const size_t inputIdx) {
+    constexpr size_t elemBits = sizeof(T) * 8;
+    const size_t elemOffset = inputIdx / elemBits;
+    const size_t bitOffset = inputIdx % elemBits;
+    const T mask = 0x1U << bitOffset;
+    return (bool)(inputMatrix[elemOffset] & mask);
+}
+
+template <>
+inline void matmulPerformIOAddition<uint8_t, bool, true>(uint8_t* outputMatrix,
+                                                         const size_t outputIdx,
+                                                         const bool* inputMatrix,
+                                                         const size_t inputIdx) {
+    if (inputMatrix[inputIdx]) {
+        matmulFlipSingleBit(outputMatrix, outputIdx);
     }
-    j = count - leftover;
-#endif
-    for (; j < count; j++) {
-        vect1[j] += vect2[j];
-    }
+}
+
+template <>
+inline void matmulPerformIOAddition<bool, uint8_t, true>(bool* outputMatrix,
+                                                         const size_t outputIdx,
+                                                         const uint8_t* inputMatrix,
+                                                         const size_t inputIdx) {
+    outputMatrix[outputIdx] = (outputMatrix[outputIdx] != matmulGetSingleBit(inputMatrix, inputIdx));
 }

--- a/test/unit/test_mult.cpp
+++ b/test/unit/test_mult.cpp
@@ -8,7 +8,7 @@ TEST(Mult, vectorAddDouble) {
     std::vector<double> v1(8, 0);
     std::vector<double> v2 = {9.0, 1.111, 3.14159, 100000, 88, 100000000.1, 99, 2.7};
     // Only add the first four values.
-    grgl::vectorAdd<double>(v1.data(), v2.data(), 4);
+    grgl::vectorAdd<double, false>(v1.data(), v2.data(), 0, 0, 4);
     for (size_t i = 4; i < 8; i++) {
         ASSERT_EQ(v1[i], 0.0);
     }
@@ -17,20 +17,20 @@ TEST(Mult, vectorAddDouble) {
     }
 
     v1 = std::move(std::vector<double>(8, 0));
-    grgl::vectorAdd<double>(v1.data(), v2.data(), 5);
+    grgl::vectorAdd<double, false>(v1.data(), v2.data(), 0, 0, 5);
     ASSERT_EQ(v1[3], v2[3]);
     ASSERT_EQ(v1[4], v2[4]);
     ASSERT_EQ(v1[5], 0.0);
 
     v1 = std::move(std::vector<double>(8, 0));
-    grgl::vectorAdd<double>(v1.data(), v2.data(), 6);
+    grgl::vectorAdd<double, false>(v1.data(), v2.data(), 0, 0, 6);
     ASSERT_EQ(v1[4], v2[4]);
     ASSERT_EQ(v1[5], v2[5]);
     ASSERT_EQ(v1[6], 0.0);
 
     v1 = std::move(std::vector<double>(8, 0));
-    grgl::vectorAdd<double>(v1.data(), v2.data(), 8);
-    grgl::vectorAdd<double>(v1.data(), v2.data(), 8);
+    grgl::vectorAdd<double, false>(v1.data(), v2.data(), 0, 0, 8);
+    grgl::vectorAdd<double, false>(v1.data(), v2.data(), 0, 0, 8);
     for (size_t i = 0; i < v1.size(); i++) {
         ASSERT_NEAR(v1[i], v2[i]*2, 0.0001);
     }
@@ -41,12 +41,12 @@ TEST(Mult, vectorAddFloat) {
     std::vector<float> v2 = {9.0, 1.111, 3.14159, std::numeric_limits<float>::max(), 88, 1000.1, 99, 2.7,
                              1, 2, 3, 4, 5, 6, 7, 8};
     ASSERT_EQ(v1.size(), v2.size());
-    grgl::vectorAdd<float>(v1.data(), v2.data(), v1.size());
+    grgl::vectorAdd<float, false>(v1.data(), v2.data(), 0, 0, v1.size());
     for (size_t i = 0; i < v1.size(); i++) {
         ASSERT_EQ(v1[i], v2[i]);
     }
 
-    grgl::vectorAdd<float>(v1.data(), v2.data(), 1);
+    grgl::vectorAdd<float, false>(v1.data(), v2.data(), 0, 0, 1);
     ASSERT_NEAR(v1[0], 2*v2[0], 0.0001);
     ASSERT_EQ(v1[1], v2[1]);
 }
@@ -55,7 +55,7 @@ TEST(Mult, vectorAddInt64) {
     std::vector<int64_t> v1(15, 0);
     std::vector<int64_t> v2 = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2};
     ASSERT_EQ(v1.size(), v2.size());
-    grgl::vectorAdd<int64_t>(v1.data(), v2.data(), v1.size());
+    grgl::vectorAdd<int64_t, false>(v1.data(), v2.data(), 0, 0, v1.size());
     for (size_t i = 0; i < v1.size(); i++) {
         ASSERT_EQ(v1[i], v2[i]);
     }
@@ -65,8 +65,52 @@ TEST(Mult, vectorAddInt32) {
     std::vector<int32_t> v1(15, 0);
     std::vector<int32_t> v2 = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2};
     ASSERT_EQ(v1.size(), v2.size());
-    grgl::vectorAdd<int32_t>(v1.data(), v2.data(), v1.size());
+    grgl::vectorAdd<int32_t, false>(v1.data(), v2.data(), 0, 0, v1.size());
     for (size_t i = 0; i < v1.size(); i++) {
         ASSERT_EQ(v1[i], v2[i]);
     }
+}
+
+TEST(Mult, matmulPerformIOAddition) {
+    bool testInput[20] = {false};
+    for (size_t i = 0; i < 20; i++) {
+        ASSERT_EQ(testInput[i], false);
+    }
+    // 20 * 8 == 160 bits.
+    uint8_t bitvector[20] = {0};
+
+    // Bitwise IO test: round-trip a single bit flip. We set the 5'th booled input, and then map
+    // it to the 99th bit. Then we map the 99th
+    testInput[5] = true;
+    grgl::matmulPerformIOAddition<uint8_t, bool, true>(&bitvector[0], 99, &testInput[0], 5);
+    grgl::matmulPerformIOAddition<bool, uint8_t, true>(&testInput[0], 15, &bitvector[0], 99);
+    ASSERT_EQ(testInput[5], true);
+    ASSERT_EQ(testInput[15], true);
+    ASSERT_EQ(testInput[19], false);
+}
+
+TEST(Mult, vectorAddBitvector) {
+    uint8_t bitvector1[20] = {0};
+    uint8_t bitvector2[20] = {0};
+
+    // Add (xor) bv1[16-23] and bv2[24-31] together.
+    bitvector1[2] = 0xFF;
+    bitvector2[3] = 0x00;
+    grgl::vectorAdd<uint8_t, true>(&bitvector1[0], &bitvector2[0], 16, 24, 8);
+    ASSERT_EQ(bitvector1[2], 0xFF);
+
+    bitvector1[2] = 0xFF;
+    bitvector2[4] = 0xFF;
+    grgl::vectorAdd<uint8_t, true>(&bitvector1[0], &bitvector2[0], 16, 32, 8);
+    ASSERT_EQ(bitvector1[2], 0x00);
+
+    bitvector1[2] = 0xF0;
+    bitvector2[9] = 0x0F;
+    grgl::vectorAdd<uint8_t, true>(&bitvector1[0], &bitvector2[0], 16, 9*8, 8);
+    ASSERT_EQ(bitvector1[2], 0xFF);
+
+    bitvector1[9] = 0xFF;
+    bitvector2[3] = 0x0F;
+    grgl::vectorAdd<uint8_t, true>(&bitvector1[0], &bitvector2[0], 9*8, 24, 8);
+    ASSERT_EQ(bitvector1[9], 0xF0);
 }


### PR DESCRIPTION
Using a smaller numpy datatype saves memory and also speeds up computation. For general "counting" computation, you cannot use anything smaller than numpy.int32 because a GRG can have up to (2**32)-2 nodes in the graph. However, in special cases the int16 and int8 could be useful.

One special case that is useful is the boolean problem, where the input as a vector with a single 1 and the rest are zeros. This can be used to explicitly retrieve thegenotype matrix, for example. In this case, we only need boolean values, and matmul now stores all node values packed into a bitvectors.