### PR TITLE
Node initialization option for `matmul()`

### DIFF
--- a/include/grgl/internal_mult.h
+++ b/include/grgl/internal_mult.h
@@ -6,6 +6,9 @@ template <typename T, typename T2, bool useBitVector>
 inline void
 matmulPerformIOAddition(T* outputMatrix, const size_t outputIdx, const T2* inputMatrix, const size_t inputIdx);
 
+template <typename T, typename T2, bool useBitVector>
+inline void matmulPerformIOAddition(T* outputMatrix, const size_t outputIdx, const T2 inputValue, const size_t count);
+
 template <typename T> class ValueSumVisitor : public GRGVisitor {
 public:
     explicit ValueSumVisitor(std::vector<T>& nodeValues, const size_t numRows = 1)
@@ -166,6 +169,14 @@ matmulPerformIOAdditionHelper(T* outputMatrix, const size_t outputIdx, const T* 
     outputMatrix[outputIdx] += inputMatrix[inputIdx];
 }
 
+template <typename T>
+inline void
+matmulPerformIOAdditionHelper(T* outputMatrix, const size_t outputIdx, const T inputValue, const size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        outputMatrix[outputIdx + i] += inputValue;
+    }
+}
+
 template <>
 inline void matmulPerformIOAddition<double, double, false>(double* outputMatrix,
                                                            const size_t outputIdx,
@@ -246,6 +257,86 @@ inline void matmulPerformIOAddition<uint8_t, uint8_t, false>(uint8_t* outputMatr
     matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputMatrix, inputIdx);
 }
 
+template <>
+inline void matmulPerformIOAddition<double, double, false>(double* outputMatrix,
+                                                           const size_t outputIdx,
+                                                           const double inputValue,
+                                                           const size_t count) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputValue, count);
+}
+
+template <>
+inline void matmulPerformIOAddition<float, float, false>(float* outputMatrix,
+                                                         const size_t outputIdx,
+                                                         const float inputValue,
+                                                         const size_t count) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputValue, count);
+}
+
+template <>
+inline void matmulPerformIOAddition<int64_t, int64_t, false>(int64_t* outputMatrix,
+                                                             const size_t outputIdx,
+                                                             const int64_t inputValue,
+                                                             const size_t count) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputValue, count);
+}
+
+template <>
+inline void matmulPerformIOAddition<int32_t, int32_t, false>(int32_t* outputMatrix,
+                                                             const size_t outputIdx,
+                                                             const int32_t inputValue,
+                                                             const size_t count) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputValue, count);
+}
+
+template <>
+inline void matmulPerformIOAddition<int16_t, int16_t, false>(int16_t* outputMatrix,
+                                                             const size_t outputIdx,
+                                                             const int16_t inputValue,
+                                                             const size_t count) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputValue, count);
+}
+
+template <>
+inline void matmulPerformIOAddition<int8_t, int8_t, false>(int8_t* outputMatrix,
+                                                           const size_t outputIdx,
+                                                           const int8_t inputValue,
+                                                           const size_t count) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputValue, count);
+}
+
+template <>
+inline void matmulPerformIOAddition<uint64_t, uint64_t, false>(uint64_t* outputMatrix,
+                                                               const size_t outputIdx,
+                                                               const uint64_t inputValue,
+                                                               const size_t count) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputValue, count);
+}
+
+template <>
+inline void matmulPerformIOAddition<uint32_t, uint32_t, false>(uint32_t* outputMatrix,
+                                                               const size_t outputIdx,
+                                                               const uint32_t inputValue,
+                                                               const size_t count) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputValue, count);
+}
+
+template <>
+inline void matmulPerformIOAddition<uint16_t, uint16_t, false>(uint16_t* outputMatrix,
+                                                               const size_t outputIdx,
+                                                               const uint16_t inputValue,
+                                                               const size_t count) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputValue, count);
+}
+
+template <>
+inline void matmulPerformIOAddition<uint8_t, uint8_t, false>(uint8_t* outputMatrix,
+                                                             const size_t outputIdx,
+                                                             const uint8_t inputValue,
+                                                             const size_t count) {
+    matmulPerformIOAdditionHelper(outputMatrix, outputIdx, inputValue, count);
+}
+
 // If the input bit is 0, leave output unchanged. If the input bit is 1, flip the output
 // value to the other value.
 template <typename T> inline void matmulFlipSingleBit(T* outputMatrix, const size_t outputIdx) {
@@ -280,4 +371,12 @@ inline void matmulPerformIOAddition<bool, uint8_t, true>(bool* outputMatrix,
                                                          const uint8_t* inputMatrix,
                                                          const size_t inputIdx) {
     outputMatrix[outputIdx] = (outputMatrix[outputIdx] != matmulGetSingleBit(inputMatrix, inputIdx));
+}
+
+template <>
+inline void matmulPerformIOAddition<uint8_t, bool, true>(uint8_t* outputMatrix,
+                                                         const size_t outputIdx,
+                                                         const bool inputValue,
+                                                         const size_t count) {
+    release_assert(false); // Unsupported
 }

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -79,11 +79,59 @@ inline py::array_t<IOType> dispatchMult(grgl::GRGPtr& grg,
                                         size_t outCols,
                                         grgl::TraversalDirection direction,
                                         bool emitAllNodes,
-                                        bool byIndividual) {
+                                        bool byIndividual,
+                                        py::handle init) {
     const size_t outSize = rows * outCols;
     py::array_t<IOType> result({rows, outCols});
     py::buffer_info resultBuf = result.request();
     memset(resultBuf.ptr, 0, outSize * sizeof(IOType));
+
+    // If the node initialization was specified, it can either be:
+    // 1. A list of values, each of which is either a constant integer/float value or
+    //    the string "xtx" to use the coalescence counts.
+    // 2. A matrix that matches the dimensions of the input
+    py::buffer_info initBuffer;
+    grgl::GRG::NodeInitEnum nodeInitMode = grgl::GRG::NIE_ZERO;
+    if (py::isinstance<py::none>(init)) {
+        ;
+    } else if (py::isinstance<py::str>(init)) {
+        if (init.cast<std::string>() == "xtx") {
+            nodeInitMode = grgl::GRG::NIE_XTX;
+        } else {
+            std::stringstream ssErr;
+            ssErr << "Unexpected init value: " << init.cast<std::string>();
+            throw grgl::ApiMisuseFailure(ssErr.str().c_str());
+        }
+    } else {
+        py::array arr = py::array::ensure(init, py::array::c_style | py::array::forcecast);
+        if (py::isinstance<py::array_t<IOType>>(init)) {
+            initBuffer = arr.request();
+            if (initBuffer.ndim == 1) {
+                const size_t initRows = initBuffer.shape.at(0);
+                if (initRows != rows) {
+                    std::stringstream ssErr;
+                    ssErr << "If init has a single dimension, it must match the number of rows in the input matrix";
+                    throw grgl::ApiMisuseFailure(ssErr.str().c_str());
+                }
+                nodeInitMode = grgl::GRG::NIE_VECTOR;
+            }
+            if (initBuffer.ndim == 2) {
+                const size_t initRows = initBuffer.shape.at(0);
+                const size_t initCols = initBuffer.shape.at(1);
+                if (initRows != rows || initCols != grg->numNodes()) {
+                    std::stringstream ssErr;
+                    ssErr << "If init is a matrix, it must match the dimensions ROW x NODES";
+                    throw grgl::ApiMisuseFailure(ssErr.str().c_str());
+                }
+                nodeInitMode = grgl::GRG::NIE_MATRIX;
+            }
+        } else {
+            std::stringstream ssErr;
+            ssErr << "The init matrix must match the dtype of the input matrix. Got: " << arr.dtype();
+            throw grgl::ApiMisuseFailure(ssErr.str().c_str());
+        }
+    }
+
     grg->matrixMultiplication<IOType, NodeValueType, useBitVector>((const IOType*)buffer.ptr,
                                                                    inCols,
                                                                    rows,
@@ -91,7 +139,9 @@ inline py::array_t<IOType> dispatchMult(grgl::GRGPtr& grg,
                                                                    (IOType*)resultBuf.ptr,
                                                                    outSize,
                                                                    emitAllNodes,
-                                                                   byIndividual);
+                                                                   byIndividual,
+                                                                   (const IOType*)initBuffer.ptr,
+                                                                   nodeInitMode);
     return std::move(result);
 }
 
@@ -99,7 +149,8 @@ py::array matMul(grgl::GRGPtr& grg,
                  py::handle input,
                  grgl::TraversalDirection direction,
                  bool emitAllNodes = false,
-                 bool byIndividual = false) {
+                 bool byIndividual = false,
+                 py::handle init = nullptr) {
     py::array arr = py::array::ensure(input, py::array::c_style | py::array::forcecast);
     py::buffer_info buffer = arr.request();
     if (buffer.ndim != 2) {
@@ -117,37 +168,40 @@ py::array matMul(grgl::GRGPtr& grg,
 
     if (py::isinstance<py::array_t<double>>(input)) {
         return dispatchMult<double, double, false>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     } else if (py::isinstance<py::array_t<float>>(input)) {
         return dispatchMult<float, float, false>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     } else if (py::isinstance<py::array_t<std::int64_t>>(input)) {
         return dispatchMult<int64_t, int64_t, false>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     } else if (py::isinstance<py::array_t<std::int32_t>>(input)) {
         return dispatchMult<int32_t, int32_t, false>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     } else if (py::isinstance<py::array_t<std::int16_t>>(input)) {
         return dispatchMult<int16_t, int16_t, false>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     } else if (py::isinstance<py::array_t<std::int8_t>>(input)) {
         return dispatchMult<int8_t, int8_t, false>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     } else if (py::isinstance<py::array_t<std::uint64_t>>(input)) {
         return dispatchMult<uint64_t, uint64_t, false>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     } else if (py::isinstance<py::array_t<std::uint32_t>>(input)) {
         return dispatchMult<uint32_t, uint32_t, false>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     } else if (py::isinstance<py::array_t<std::uint16_t>>(input)) {
         return dispatchMult<uint16_t, uint16_t, false>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     } else if (py::isinstance<py::array_t<std::uint8_t>>(input)) {
         return dispatchMult<uint8_t, uint8_t, false>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     } else if (py::isinstance<py::array_t<bool>>(input)) {
+        if (!py::isinstance<py::none>(init)) {
+            throw grgl::ApiMisuseFailure("init=... is not supported with boolean dtype");
+        }
         return dispatchMult<bool, uint8_t, true>(
-            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual);
+            grg, buffer, rows, cols, outCols, direction, emitAllNodes, byIndividual, init);
     }
     std::stringstream ssErr;
     ssErr << "Unsupported numpy dtype: " << arr.dtype();
@@ -743,6 +797,7 @@ PYBIND11_MODULE(_grgl, m) {
           py::arg("direction"),
           py::arg("emit_all_nodes") = false,
           py::arg("by_individual") = false,
+          py::arg("init") = nullptr,
           R"^(
         Compute one of two possible matrix multiplications across the entire
         graph. The input matrix :math:`V` can be either :math:`K \times N` (:math:`N`

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -86,10 +86,6 @@ inline py::array_t<IOType> dispatchMult(grgl::GRGPtr& grg,
     py::buffer_info resultBuf = result.request();
     memset(resultBuf.ptr, 0, outSize * sizeof(IOType));
 
-    // If the node initialization was specified, it can either be:
-    // 1. A list of values, each of which is either a constant integer/float value or
-    //    the string "xtx" to use the coalescence counts.
-    // 2. A matrix that matches the dimensions of the input
     py::buffer_info initBuffer;
     grgl::GRG::NodeInitEnum nodeInitMode = grgl::GRG::NIE_ZERO;
     if (py::isinstance<py::none>(init)) {
@@ -838,6 +834,16 @@ PYBIND11_MODULE(_grgl, m) {
             of :math:`N` (:py:attr:`num_samples`) columns, it is :math:`N / ploidy` (:py:attr:`num_individuals`)
             columns.
         :type by_individual: bool
+        :param init: Initialization of the nodes of the graph during matrix multiplication. By default (when this
+            is set to None), nodes are initialization to 0. There are three possible types this can take on:
+            1. A string "xtx" which means to initialize the nodes with twice their coalesence counts. Using this
+            and performing an UP multiplication (with 1s as input) produces the X.T * X product needed for
+            GWAS.
+            2. A one dimensional numpy array (vector) of length K. The value at position K is assigned to all
+            nodes when performing the multiplication for row K from the input matrix.
+            3. A two dimensional numpy array (matrix) of size KxT, where T is the total number of nodes in the
+            graph (grg.num_nodes). This fully specifies every node value for the entire matrix operation.
+        :type init: Union[str, numpy.array]
         :return: The numpy 2-dimensional array of output values.
         :rtype: numpy.array
     )^");


### PR DESCRIPTION
`matmul(init=...)` option lets you specify how node values are accumulated during matrix multiplication. The default `init=None` initializes all node values to `0`, which gives the "standard" matrix multiplication behavior of each node value `v(n) = sum(v(c) for all c in children)`.

However, if you give initialization values to nodes this becomes:
`v(n) = init(n) + sum(v(c) for all c in children)`

There are three ways to initialize:
1. `init="xtx"` initializes all nodes with two times their coalescence count. A bottom-up multiplication of `1_n` using this option will produce the product `X.T * X` (used for GWAS).
2. `init=numpy.array([1, 1, 0, ... ])` initializes all nodes to a single value for each multiplication row. An easier way to think about this is to consider an input matrix of size `KxN`. Instead of a matrix multiplication, think of this as `K` dot products. For each dot-product, set all node initialization values to the single value from that position in the initialization vector.
3. `init=numpy.array([ [1, 2, 0, ...], [0, 0, 1, ...], ... ])` initializes all nodes to their own specific value. The init matrix must be dimensions `KxT` where `T` is the total number of nodes in the graph (`grg.num_nodes`)