### PR TITLE
Upgrade picovcf and perform fast seeking to genome ranges

### DIFF
--- a/include/grgl/mut_iterator.h
+++ b/include/grgl/mut_iterator.h
@@ -146,6 +146,7 @@ protected:
 
 private:
     std::unique_ptr<picovcf::IGDData> m_igd;
+    size_t m_startVariant;
     size_t m_currentVariant;
 };
 

--- a/src/mut_iterator.cpp
+++ b/src/mut_iterator.cpp
@@ -254,6 +254,7 @@ IGDMutationIterator::IGDMutationIterator(
     } else {
         m_startVariant = m_igd->lowerBoundPosition((size_t)std::ceil(m_genomeRange.start()));
     }
+    m_currentVariant = m_startVariant;
 }
 
 void IGDMutationIterator::getMetadata(size_t& ploidy, size_t& numIndividuals, bool& isPhased) {


### PR DESCRIPTION
Use the new binary search feature of the IGD index to find the location for creating the partial GRG (tGRG). This can speedup construction significantly for large datasets.

Thousand genomes chromosome 22 builds about 3x faster. The way we build this dataset uses a ton of trees, which each need to seek to the right location, so this is an edge case for sure (most won't be 3x faster).

50k individuals stdpopsim dataset is only about 15% faster, which makes sense.