### PR TITLE
Rebuild nearest neighbor index periodically

### DIFF
--- a/src/build_shape.cpp
+++ b/src/build_shape.cpp
@@ -43,7 +43,9 @@ static NodeIDList addGrgShapeFromHashing(const MutableGRGPtr& grg,
     auto compareNodeIds = [&](const NodeID& node1, const NodeID& node2) {
         return bitwiseHamming(nodeHashes.at(node1), nodeHashes.at(node2));
     };
-    HaplotypeIndex hashIndex(compareNodeIds);
+    // Rebuild the nearest neighbor index when it reached 25% deleted.
+    constexpr double rebuildProportion = 0.25;
+    HaplotypeIndex hashIndex(compareNodeIds, rebuildProportion);
 
     NodeIDSet covered;
     NodeIDList levelNodes;

--- a/src/hap_index.h
+++ b/src/hap_index.h
@@ -41,8 +41,10 @@ using NodeToHapVect = std::vector<HaplotypeVector>;
  */
 class HaplotypeIndex {
 public:
-    explicit HaplotypeIndex(std::function<size_t(const NodeID&, const NodeID&)> distFunc)
-        : m_bkTree(std::move(distFunc)) {}
+    explicit HaplotypeIndex(std::function<size_t(const NodeID&, const NodeID&)> distFunc,
+                            const double rebuildProportion = 2.0)
+        : m_bkTree(std::move(distFunc))
+        , m_rebuildProportion(rebuildProportion) {}
 
     virtual ~HaplotypeIndex() = default;
 
@@ -70,10 +72,12 @@ public:
     void emitStats() const {
         std::cout << " -- Index Stats --" << std::endl;
         std::cout << "  -> Comparisons: " << m_comparisons << std::endl;
+        m_bkTree.dumpStats();
     }
 
 private:
     LeanBKTree<NodeID> m_bkTree;
+    const double m_rebuildProportion;
     // Keep track of how many comparisons we do.
     size_t m_comparisons{};
 };


### PR DESCRIPTION
Speeds up access, because the BK-Tree can get pretty full of deleted items.

Has minimal effect on datasets generated with lots of trees, but larger effect when the trees/dataset are bigger (e.g., more samples).