### PR TITLE
Faster GRG merge, retains more hierarchy

### DIFF
--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -159,6 +159,11 @@ public:
     virtual bool hasUpEdges() const = 0;
 
     /**
+     * True if the edges in this graph are always in ascending NodeID order.
+     */
+    virtual bool edgesAreOrdered() const = 0;
+
+    /**
      * True iff the mutations are ordered according to position and the alternate allele (in that order).
      */
     bool mutationsAreOrdered() const { return m_mutsAreOrdered; }
@@ -598,6 +603,8 @@ public:
 
     bool hasUpEdges() const override { return true; }
 
+    bool edgesAreOrdered() const override { return false; }
+
     /**
      * Create a new node in the GRG.
      *
@@ -718,6 +725,8 @@ public:
     size_t numDownEdges(NodeID nodeId) override { return m_downEdges.numValuesAt(nodeId); }
 
     bool hasUpEdges() const override { return m_upEdges.numNodes() > 0; }
+
+    bool edgesAreOrdered() const override { return true; }
 
     size_t numUpEdges(NodeID nodeId) override {
         if (!hasUpEdges()) {

--- a/src/hap_index.h
+++ b/src/hap_index.h
@@ -43,8 +43,8 @@ class HaplotypeIndex {
 public:
     explicit HaplotypeIndex(std::function<size_t(const NodeID&, const NodeID&)> distFunc,
                             const double rebuildProportion = 2.0)
-        : m_bkTree(std::move(distFunc))
-        , m_rebuildProportion(rebuildProportion) {}
+        : m_bkTree(std::move(distFunc)),
+          m_rebuildProportion(rebuildProportion) {}
 
     virtual ~HaplotypeIndex() = default;
 

--- a/src/lean_bk_tree.h
+++ b/src/lean_bk_tree.h
@@ -150,8 +150,7 @@ public:
         return results;
     }
 
-    template <typename Container>
-    void deleteNode(NodePointer node, Container& result) {
+    template <typename Container> void deleteNode(NodePointer node, Container& result) {
         release_assert(!node->m_isDeleted);
         node->moveElements(result);
         m_deletedNodes++;
@@ -160,12 +159,10 @@ public:
     void dumpStats() const {
         std::cout << "Nodes: " << m_totalNodes << "\n";
         std::cout << "Deleted: " << m_deletedNodes << "\n";
-        std::cout << "Proportion: " << (double)m_deletedNodes/(double)m_totalNodes << "\n";
+        std::cout << "Proportion: " << (double)m_deletedNodes / (double)m_totalNodes << "\n";
     }
 
-    double deletedProportion() const {
-        return (double)m_deletedNodes/(double)m_totalNodes;
-    }
+    double deletedProportion() const { return (double)m_deletedNodes / (double)m_totalNodes; }
 
     std::vector<ElementType> removeAllElements() {
         if (!m_rootNode) {
@@ -188,6 +185,7 @@ public:
     }
 
     std::function<size_t(const ElementType&, const ElementType&)> m_distFunc;
+
 private:
     NodePointer m_rootNode{};
     size_t m_totalNodes{};


### PR DESCRIPTION
Much faster GRG merge, with the expectation for lower RAM usage on large GRGs as well. Previously we mapped based on the samples beneath a node, which could change the subtree beneath a node, sometimes removing hierarchy. It is better to keep hierarchy at the cost of a little bit larger graph. Also, the new algorithm does not propoagate data transitively in the graph, it only looks at immediate children, which makes it much more efficient.