### PR TITLE
Split genome by variant ranges

### DIFF
--- a/extra/gtime.cpp
+++ b/extra/gtime.cpp
@@ -22,9 +22,7 @@ static void mutationIteratorScan(const std::string& inFilename,
     std::shared_ptr<grgl::MutationIterator> iterator = grgl::makeMutationIterator(
         inFilename,
         /*genomeRange=*/{},
-        /*binaryMutations=*/false,
-        /*emitMissingData=*/false,
-        /*flipRefMajor=*/false);
+        grgl::MIT_FLAG_EMPTY);
     grgl::MutationAndSamples mutAndSamples;
     size_t variantCount = 0;
     size_t _unused = 0;

--- a/include/grgl/mut_iterator.h
+++ b/include/grgl/mut_iterator.h
@@ -75,7 +75,7 @@ struct MutationAndSamples {
 class MutationIterator {
 public:
     explicit MutationIterator(FloatRange genomeRange, MutationIteratorFlags flags)
-        : m_genomeRange(genomeRange),
+        : m_genomeRange(genomeRange.toIntRange()),
           m_flags(flags) {}
     virtual ~MutationIterator() = default;
 
@@ -97,7 +97,7 @@ public:
 
     size_t numFlippedAlleles() const { return m_flippedAlleles; }
 
-    FloatRange getBpRange() const { return m_genomeRange; }
+    IntRange getBpRange() const { return m_genomeRange; }
 
     bool binaryMutations() const { return (bool)(m_flags & MIT_FLAG_BINARY_MUTATIONS); }
 
@@ -117,7 +117,7 @@ protected:
     std::list<MutationAndSamples> m_alreadyLoaded;
 
     // Range to use.
-    FloatRange m_genomeRange;
+    IntRange m_genomeRange;
 
     // Current variant (index)
     size_t m_currentVariant{};

--- a/include/grgl/mut_iterator.h
+++ b/include/grgl/mut_iterator.h
@@ -35,6 +35,22 @@ struct bgen_partition;
 
 namespace grgl {
 
+using MutationIteratorFlags = uint64_t;
+enum {
+    ///< Empty flags.
+    MIT_FLAG_EMPTY = 0x0,
+    ///< Convert variants to be biallelic, collapsing alt alleles into a single one.
+    MIT_FLAG_BINARY_MUTATIONS = 0x1,
+    ///< If there is missing data, emit it as a separate Mutation.
+    MIT_FLAG_EMIT_MISSING_DATA = 0x2,
+    ///< Flip the major allele to be the reference allele, where necessary.
+    MIT_FLAG_FLIP_REF_MAJOR = 0x4,
+    ///< Skip mutations with no samples.
+    MIT_FLAG_SKIP_EMPTY = 0x8,
+    ///< Treat range as a range across _numbered variants_ instead of base pairs.
+    MIT_FLAG_USE_VARIANT_RANGE = 0x10,
+};
+
 class Mutation;
 
 struct MutationAndSamples {
@@ -58,14 +74,9 @@ struct MutationAndSamples {
  */
 class MutationIterator {
 public:
-    explicit MutationIterator(FloatRange genomeRange,
-                              bool binaryMutations,
-                              bool emitMissingData,
-                              bool flipRefMajor = false)
+    explicit MutationIterator(FloatRange genomeRange, MutationIteratorFlags flags)
         : m_genomeRange(genomeRange),
-          m_binaryMutations(binaryMutations),
-          m_emitMissingData(emitMissingData),
-          m_flipRefMajor(flipRefMajor) {}
+          m_flags(flags) {}
     virtual ~MutationIterator() = default;
 
     MutationIterator(const MutationIterator& rhs) = delete;
@@ -79,12 +90,24 @@ public:
 
     virtual size_t countMutations() const = 0;
 
+    bool inRange(size_t variantIndex, size_t position) const;
+
     bool next(MutationAndSamples& mutAndSamples, size_t& totalSamples);
     void reset();
 
     size_t numFlippedAlleles() const { return m_flippedAlleles; }
 
     FloatRange getBpRange() const { return m_genomeRange; }
+
+    bool binaryMutations() const { return (bool)(m_flags & MIT_FLAG_BINARY_MUTATIONS); }
+
+    bool emitMissingData() const { return (bool)(m_flags & MIT_FLAG_EMIT_MISSING_DATA); }
+
+    bool flipRefMajor() const { return (bool)(m_flags & MIT_FLAG_FLIP_REF_MAJOR); }
+
+    bool skipEmpty() const { return (bool)(m_flags & MIT_FLAG_SKIP_EMPTY); }
+
+    bool useVariantRange() const { return (bool)(m_flags & MIT_FLAG_USE_VARIANT_RANGE); }
 
 protected:
     virtual void buffer_next(size_t& totalSamples) = 0;
@@ -96,13 +119,14 @@ protected:
     // Range to use.
     FloatRange m_genomeRange;
 
+    // Current variant (index)
+    size_t m_currentVariant{};
+
     // How many alleles were flipped due to m_flipRefMajor?
     size_t m_flippedAlleles{};
     // Remember how many samples we saw last "row"
     size_t m_totalSamples{};
-    bool m_binaryMutations;
-    bool m_emitMissingData;
-    bool m_flipRefMajor;
+    MutationIteratorFlags m_flags;
 };
 
 /**
@@ -113,8 +137,7 @@ protected:
  */
 class VCFMutationIterator : public MutationIterator {
 public:
-    explicit VCFMutationIterator(
-        const char* filename, FloatRange genomeRange, bool binaryMutations, bool emitMissingData, bool flipRefMajor);
+    explicit VCFMutationIterator(const char* filename, FloatRange genomeRange, MutationIteratorFlags flags);
 
     void getMetadata(size_t& ploidy, size_t& numIndividuals, bool& isPhased) override;
     size_t countMutations() const override;
@@ -133,8 +156,7 @@ private:
  */
 class IGDMutationIterator : public MutationIterator {
 public:
-    explicit IGDMutationIterator(
-        const char* filename, FloatRange genomeRange, bool binaryMutations, bool emitMissingData, bool flipRefMajor);
+    explicit IGDMutationIterator(const char* filename, FloatRange genomeRange, MutationIteratorFlags flags);
 
     void getMetadata(size_t& ploidy, size_t& numIndividuals, bool& isPhased) override;
     size_t countMutations() const override;
@@ -146,8 +168,7 @@ protected:
 
 private:
     std::unique_ptr<picovcf::IGDData> m_igd;
-    size_t m_startVariant;
-    size_t m_currentVariant;
+    size_t m_startVariant{};
 };
 
 #if BGEN_ENABLED
@@ -158,8 +179,7 @@ private:
  */
 class BGENMutationIterator : public MutationIterator {
 public:
-    explicit BGENMutationIterator(
-        const char* filename, FloatRange genomeRange, bool binaryMutations, bool emitMissingData, bool flipRefMajor);
+    explicit BGENMutationIterator(const char* filename, FloatRange genomeRange, MutationIteratorFlags flags);
     ~BGENMutationIterator() override;
 
     void getMetadata(size_t& ploidy, size_t& numIndividuals, bool& isPhased) override;
@@ -177,8 +197,8 @@ private:
 };
 #endif
 
-std::shared_ptr<grgl::MutationIterator> makeMutationIterator(
-    const std::string& filename, FloatRange genomeRange, bool binaryMutations, bool emitMissingData, bool flipRefMajor);
+std::shared_ptr<grgl::MutationIterator>
+makeMutationIterator(const std::string& filename, FloatRange genomeRange, MutationIteratorFlags flags);
 
 } // namespace grgl
 

--- a/pygrgl/clicmd/construct.py
+++ b/pygrgl/clicmd/construct.py
@@ -140,6 +140,12 @@ def build_shape(range_triple, args, input_file):
     span = upper - lower
     pspans = span / args.trees
 
+    # For IGD or BGEN, split the file by variant counts, because indexing is very easy and
+    # the resulting GRG should be better and faster to create.
+    suffix = ""
+    if input_file.endswith(".igd") or input_file.endswith(".bgen"):
+        suffix = "v"
+
     for tnum in range(args.trees):
         base = lower + (tnum * pspans)
         command = [grgl_exe, input_file]
@@ -157,7 +163,7 @@ def build_shape(range_triple, args, input_file):
                 "-l",
                 "-s",
                 "-r",
-                f"{base}:{base+pspans}",
+                f"{base}:{base+pspans}{suffix}",
                 "-o",
                 out_filename_tree(input_file, part, tnum),
             ]

--- a/pygrgl/clicmd/construct.py
+++ b/pygrgl/clicmd/construct.py
@@ -134,17 +134,21 @@ def out_filename(input_file, part):
     return f"{base_name}.part{part}.grg"
 
 
-def build_shape(range_triple, args, input_file):
-    part, lower, upper = range_triple
-    assert lower < upper
-    span = upper - lower
-    pspans = span / args.trees
-
+def get_default_range_suffix(input_file: str) -> str:
     # For IGD or BGEN, split the file by variant counts, because indexing is very easy and
     # the resulting GRG should be better and faster to create.
     suffix = ""
     if input_file.endswith(".igd") or input_file.endswith(".bgen"):
         suffix = "v"
+    return suffix
+
+
+def build_shape(range_triple, args, input_file):
+    part, lower, upper = range_triple
+    assert lower < upper
+    span = upper - lower
+    pspans = span / args.trees
+    suffix = get_default_range_suffix(input_file)
 
     for tnum in range(args.trees):
         base = lower + (tnum * pspans)
@@ -198,13 +202,14 @@ def build_grg(range_triple, args, input_file):
     shape_grg = build_shape(range_triple, args, input_file)
     part, lower, upper = range_triple
     command = [grgl_exe, shape_grg]
+    suffix = get_default_range_suffix(input_file)
     if args.maf_flip:
         command.append("--maf-flip")
     command.extend(
         [
             "-s",
             "-r",
-            f"{lower}:{upper}",
+            f"{lower}:{upper}{suffix}",
             "-m",
             input_file,
             "-o",

--- a/src/build_shape.cpp
+++ b/src/build_shape.cpp
@@ -255,6 +255,7 @@ MutableGRGPtr createEmptyGRGFromSamples(const std::string& sampleFile,
                                         FloatRange& genomeRange,
                                         size_t bitsPerMutation,
                                         GrgBuildFlags buildFlags,
+                                        MutationIteratorFlags itFlags,
                                         const double dropBelowThreshold,
                                         const std::map<std::string, std::string>& indivIdToPop,
                                         const size_t tripletLevels) {
@@ -269,11 +270,7 @@ MutableGRGPtr createEmptyGRGFromSamples(const std::string& sampleFile,
     } while (0)
 
     GRGBS_LOG_OUTPUT("Building genotype hash index..." << std::endl);
-    const bool useBinaryMuts = static_cast<bool>(buildFlags & GBF_USE_BINARY_MUTS);
-    const bool emitMissingData = static_cast<bool>(buildFlags & GBF_EMIT_MISSING_DATA);
-    const bool flipRefMajor = static_cast<bool>(buildFlags & GBF_FLIP_REF_MAJOR);
-    std::shared_ptr<grgl::MutationIterator> mutationIterator =
-        makeMutationIterator(sampleFile, genomeRange, useBinaryMuts, emitMissingData, flipRefMajor);
+    std::shared_ptr<grgl::MutationIterator> mutationIterator = makeMutationIterator(sampleFile, genomeRange, itFlags);
     auto operationStartTime = std::chrono::high_resolution_clock::now();
     uint16_t ploidy = genotypeHashIndex(*mutationIterator, hashIndex, bitsPerMutation, dropBelowThreshold);
     GRGBS_LOG_OUTPUT("** Hashing input took " << std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/build_shape.h
+++ b/src/build_shape.h
@@ -21,6 +21,7 @@
 
 #include "grgl/common.h"
 #include "grgl/grgnode.h"
+#include "grgl/mut_iterator.h"
 #include "grgl/mutation.h"
 #include "util.h"
 
@@ -30,11 +31,9 @@ class MutableGRG;
 using MutableGRGPtr = std::shared_ptr<MutableGRG>;
 
 enum {
-    GBF_USE_BINARY_MUTS = 0x1U,
-    GBF_EMIT_MISSING_DATA = 0x2U,
-    GBF_FLIP_REF_MAJOR = 0x4U,
-    GBF_NO_INDIVIDUAL_IDS = 0x8U,
-    GBF_VERBOSE_OUTPUT = 0x10U,
+    GBF_EMPTY = 0x0U,
+    GBF_NO_INDIVIDUAL_IDS = 0x1U,
+    GBF_VERBOSE_OUTPUT = 0x2U,
 };
 using GrgBuildFlags = uint64_t;
 
@@ -46,6 +45,7 @@ MutableGRGPtr createEmptyGRGFromSamples(const std::string& sampleFile,
                                         FloatRange& genomeRange,
                                         size_t bitsPerMutation,
                                         GrgBuildFlags buildFlags,
+                                        MutationIteratorFlags itFlags,
                                         double dropBelowThreshold,
                                         const std::map<std::string, std::string>& indivIdToPop,
                                         size_t tripletLevels = 0);

--- a/src/gconverter.cpp
+++ b/src/gconverter.cpp
@@ -117,7 +117,7 @@ static void mutationIteratorToIGD(const std::string& inFilename,
 
     std::cout << "Converting " << inFilename << " to " << outFilename << std::endl;
     std::shared_ptr<grgl::MutationIterator> iterator =
-        grgl::makeMutationIterator(inFilename, restrictRange, false, true, false);
+        grgl::makeMutationIterator(inFilename, restrictRange, grgl::MIT_FLAG_EMIT_MISSING_DATA);
     size_t ploidy = 0;
     size_t numIndividuals = 0;
     bool isPhased = false;

--- a/src/grgl.cpp
+++ b/src/grgl.cpp
@@ -179,6 +179,16 @@ int main(int argc, char** argv) {
     }
 
     grgl::MutationIteratorFlags itFlags = grgl::MIT_FLAG_EMPTY;
+    if (binaryMutations) {
+        itFlags |= grgl::MIT_FLAG_BINARY_MUTATIONS;
+    }
+    if (missingDataHandling == MDH_ADD_TO_GRG) {
+        itFlags |= grgl::MIT_FLAG_EMIT_MISSING_DATA;
+    }
+    if (MAFFlip) {
+        itFlags |= grgl::MIT_FLAG_FLIP_REF_MAJOR;
+    }
+
     grgl::FloatRange restrictRange;
     if (genomeRange) {
         const std::string basePairSuffix = "b";
@@ -267,15 +277,6 @@ int main(int argc, char** argv) {
             abort();
         }
         START_TIMING_OPERATION();
-        if (binaryMutations) {
-            itFlags |= grgl::MIT_FLAG_BINARY_MUTATIONS;
-        }
-        if (missingDataHandling == MDH_ADD_TO_GRG) {
-            itFlags |= grgl::MIT_FLAG_EMIT_MISSING_DATA;
-        }
-        if (MAFFlip) {
-            itFlags |= grgl::MIT_FLAG_FLIP_REF_MAJOR;
-        }
         std::shared_ptr<grgl::MutationIterator> unmappedMutations =
             makeMutationIterator(*mapMutations, restrictRange, itFlags);
         if (!unmappedMutations) {

--- a/test/endtoend/test_basic.py
+++ b/test/endtoend/test_basic.py
@@ -29,7 +29,9 @@ def get_freqs_unordered(lines: List[str]) -> Dict[Tuple[str, str, str], int]:
     return fmap
 
 
-def construct_grg(input_file: str, output_file: Optional[str] = None) -> str:
+def construct_grg(
+    input_file: str, output_file: Optional[str] = None, test_input: bool = True
+) -> str:
     cmd = [
         "grg",
         "construct",
@@ -39,7 +41,7 @@ def construct_grg(input_file: str, output_file: Optional[str] = None) -> str:
         "2",
         "-j",
         str(JOBS),
-        os.path.join(INPUT_DIR, input_file),
+        os.path.join(INPUT_DIR, input_file) if test_input else input_file,
     ]
     if output_file is not None:
         cmd.extend(["-o", output_file])
@@ -49,13 +51,15 @@ def construct_grg(input_file: str, output_file: Optional[str] = None) -> str:
     return output_file
 
 
-class TestGrgConstruction(unittest.TestCase):
-    def test_construct_allele_freq(self):
-        # Create the GRG
-        grg_filename = construct_grg("test-200-samples.vcf.gz")
+class TestGrgBasic(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.grg_filename = construct_grg("test-200-samples.vcf.gz")
+        cls.grg = pygrgl.load_immutable_grg(cls.grg_filename)
 
+    def test_construct_allele_freq(self):
         # Use "grg process" to compute allele frequencies.
-        af = subprocess.check_output(["grg", "process", "freq", grg_filename])
+        af = subprocess.check_output(["grg", "process", "freq", self.grg_filename])
         saw_lines = list(filter(lambda l: l.strip(), af.decode("utf-8").split("\n")))
 
         # Compare computed allele frequencys against expected.
@@ -70,7 +74,7 @@ class TestGrgConstruction(unittest.TestCase):
 
         # Now compute the same values using the dot_product Python API, these we don't ensure the
         # order on (though order should match)
-        grg = pygrgl.load_immutable_grg(grg_filename)
+        grg = pygrgl.load_immutable_grg(self.grg_filename)
         input_vector = np.ones(grg.num_samples)
         api_result = pygrgl.dot_product(grg, input_vector, pygrgl.TraversalDirection.UP)
         for i in range(len(api_result)):
@@ -80,29 +84,24 @@ class TestGrgConstruction(unittest.TestCase):
                 expect_freqs_unordered[(m.position, m.ref_allele, m.allele)],
             )
 
-        if CLEANUP:
-            os.remove(grg_filename)
-
     def test_split(self):
         """
         Verify that splitting a GRG still captures all of the sample->mutation relationships.
         """
         # Create the GRG
-        grg_filename = construct_grg("test-200-samples.vcf.gz", "test.for_split.grg")
-        split_dir = f"{grg_filename}.split"
+        split_dir = f"{self.grg_filename}.split"
         assert not os.path.exists(split_dir), f"{split_dir} already exists; remove it"
 
-        check_grg = pygrgl.load_immutable_grg(grg_filename)
         maxpos = 0
-        for mut_id in range(check_grg.num_mutations):
-            maxpos = max(maxpos, check_grg.get_mutation_by_id(mut_id).position)
+        for mut_id in range(self.grg.num_mutations):
+            maxpos = max(maxpos, self.grg.get_mutation_by_id(mut_id).position)
         assert maxpos == 9999126
-        assert check_grg.specified_bp_range == (55829, 9999127)
-        assert check_grg.specified_bp_range == check_grg.bp_range
+        assert self.grg.specified_bp_range == (55829, 9999127)
+        assert self.grg.specified_bp_range == self.grg.bp_range
 
         # Split the GRG
         subprocess.check_output(
-            ["grg", "split", "-j", str(4), grg_filename, "-s", str(100000)]
+            ["grg", "split", "-j", str(4), self.grg_filename, "-s", str(100000)]
         )
         saw_freqs = {}
         for grg_part in glob.glob(f"{split_dir}/*.grg"):
@@ -118,14 +117,11 @@ class TestGrgConstruction(unittest.TestCase):
         self.assertEqual(saw_keys, expect_keys)
         for k in saw_keys:
             self.assertEqual(saw_freqs[k], expect_freqs[k])
-        if CLEANUP:
-            os.remove(grg_filename)
 
-
-class TestCoalescence(unittest.TestCase):
     def test_coal_counts(self):
-        grg_filename = construct_grg("test-200-samples.vcf.gz", "test.coal_counts.grg")
-        zyg_info = subprocess.check_output(["grg", "process", "zygosity", grg_filename])
+        zyg_info = subprocess.check_output(
+            ["grg", "process", "zygosity", self.grg_filename]
+        )
         saw_lines = list(
             filter(lambda l: l.strip(), zyg_info.decode("utf-8").split("\n"))
         )
@@ -139,8 +135,31 @@ class TestCoalescence(unittest.TestCase):
         for saw, expect in zip(saw_lines, expect_lines):
             self.assertEqual(saw, expect)
 
+    def test_igd_construct(self):
+        igd_filename = "test-200-samples.igd"
+        cmd = [
+            "igdtools",
+            os.path.join(INPUT_DIR, "test-200-samples.vcf.gz"),
+            "-o",
+            igd_filename,
+        ]
+        subprocess.check_call(cmd)
+        grg_filename = construct_grg(igd_filename, test_input=False)
+        grg = pygrgl.load_immutable_grg(grg_filename)
+        self.assertEqual(grg.num_samples, self.grg.num_samples)
+
+        shape = (1, grg.num_samples)
+        from_igd = pygrgl.matmul(grg, np.ones(shape), pygrgl.TraversalDirection.UP)
+        from_vcf = pygrgl.matmul(self.grg, np.ones(shape), pygrgl.TraversalDirection.UP)
+
+        self.assertTrue(np.allclose(from_igd, from_vcf))
         if CLEANUP:
             os.remove(grg_filename)
+
+    @classmethod
+    def tearDownClass(cls):
+        if CLEANUP:
+            os.remove(cls.grg_filename)
 
 
 if __name__ == "__main__":

--- a/test/unit/test_common.cpp
+++ b/test/unit/test_common.cpp
@@ -1,26 +1,54 @@
 #include <gtest/gtest.h>
+#include <limits>
 
 #include "grgl/common.h"
 
 using namespace grgl;
 
 TEST(Common, FloatRange) {
+    IntRange denorm;
     FloatRange orig;
     ASSERT_TRUE(orig.isUnspecified());
     ASSERT_EQ(orig, orig.normalized(0, 100));
-    ASSERT_EQ(orig, orig.denormalized(0, 100));
+    denorm = orig.denormalized(0, 100);
+    ASSERT_EQ((size_t)orig.start(), denorm.start());
+    ASSERT_EQ((size_t)denorm.end(), std::numeric_limits<size_t>::max());
 
     orig = {0, 1000};
     ASSERT_EQ(orig.start(), 0);
     ASSERT_EQ(orig.end(), 1000);
-    ASSERT_EQ(orig, orig.normalized(0, 1000).denormalized(0, 1000));
+    denorm = orig.normalized(0, 1000).denormalized(0, 1000);
+    ASSERT_EQ((size_t)orig.start(), denorm.start());
+    ASSERT_EQ((size_t)orig.end(), denorm.end());
+
     FloatRange firstHalf = {0, 500};
     FloatRange secondHalf = {500, 1000};
     ASSERT_FALSE(firstHalf.contains(secondHalf.start()));
     FloatRange firstHalfNorm = {0, 0.5};
     FloatRange secondHalfNorm = {0.5, 1.0};
     ASSERT_FALSE(firstHalfNorm.contains(secondHalfNorm.start()));
-    FloatRange firstHalfDenorm = firstHalfNorm.denormalized(0, 1000);
-    FloatRange secondHalfDenorm = secondHalfNorm.denormalized(0, 1000);
+    IntRange firstHalfDenorm = firstHalfNorm.denormalized(0, 1000);
+    IntRange secondHalfDenorm = secondHalfNorm.denormalized(0, 1000);
     ASSERT_FALSE(firstHalfDenorm.contains(secondHalfDenorm.start()));
+}
+
+// A range that is not evenly integer divisible should cover every positons
+// once and only once.
+TEST(Common, UnevenRange) {
+    std::vector<FloatRange> normRanges = {
+        {0, 0.333}, {0.333, 0.666}, {0.666, 1.0}
+    };
+    std::vector<IntRange> denormRanges;
+    for (const auto& range : normRanges) {
+        denormRanges.push_back(range.denormalized(0, 1000));
+    }
+    for (size_t i = 0; i < 1000; i++) {
+        size_t foundTimes = 0;
+        for (const auto& range : denormRanges) {
+            if (range.contains(i)) {
+                foundTimes++;
+            }
+        }
+        ASSERT_EQ(foundTimes, 1);
+    }
 }

--- a/test/unit/test_construct.cpp
+++ b/test/unit/test_construct.cpp
@@ -4,6 +4,7 @@
 
 #include "grgl/grg.h"
 #include "build_shape.h"
+#include "grgl/mut_iterator.h"
 #include "testing_utilities.h"
 
 using namespace grgl;
@@ -47,7 +48,7 @@ TEST(Construct, WithPopIds) {
     // Test1: Incomplete individual -> population map
     indivIdToPop.emplace("Z1", "Population2");
     indivIdToPop.emplace("X1", "Population4");
-    EXPECT_THROW(createEmptyGRGFromSamples(filename, fullRange, 8, 0x0U, 0.0,
+    EXPECT_THROW(createEmptyGRGFromSamples(filename, fullRange, 8, GBF_EMPTY, MIT_FLAG_EMPTY, 0.0,
                                            indivIdToPop), std::runtime_error);
 
     // Test2: Complete individual -> population map
@@ -56,7 +57,7 @@ TEST(Construct, WithPopIds) {
     indivIdToPop.emplace("B4", "Population3");
     indivIdToPop.emplace("A1", "Population1");
     indivIdToPop.emplace("X3", "Population4");
-    auto grg = createEmptyGRGFromSamples(filename, fullRange, 8, 0x0U, 0.0,
+    auto grg = createEmptyGRGFromSamples(filename, fullRange, 8, GBF_EMPTY, MIT_FLAG_EMPTY, 0.0,
                                          indivIdToPop);
     ASSERT_EQ(grg->numSamples(), numIndividuals*2);
     auto popDescriptions = grg->getPopulations();

--- a/test/unit/test_map_muts.cpp
+++ b/test/unit/test_map_muts.cpp
@@ -21,7 +21,7 @@ using namespace grgl;
 class TestMutationIterator : public MutationIterator {
 public:
     explicit TestMutationIterator(std::vector<Mutation> muts, std::vector<NodeIDList> samples)
-            : MutationIterator({0, 1000}, false, false) {
+            : MutationIterator({0, 1000}, MIT_FLAG_EMPTY) {
         for (size_t i = 0; i < muts.size(); i++) {
             this->m_alreadyLoaded.push_back({muts.at(i), samples.at(i)});
         }


### PR DESCRIPTION
Previously, for all input file types, the genome was split into ranges evenly according to base-pairs. Since mutation density varies along the genome (and by dataset), different graph segments had different numbers of Mutations.

The underlying GRGL construction tool now supports `v` or `b` suffix on the genome ranges given to it: the former is by variant, the latter by base pair. For example, `-r 0.5:0.51v` means the segment covering from the 50th to the 51st percentile of variants in the chromosome/genome given.

For IGD and BGEN, indexing by variant is fast and simple, so we default to `v` suffix when using `grg construct` for those input types. VCF is much slower, so (for now) we leave the default as `b` (base pair).  In the future, picovcf will support tabix indexes which will allow VCF to be more easily used, and to switch to `v` by default.