### PR TITLE
Initial support for unphased GRGs

### DIFF
--- a/include/grgl/common.h
+++ b/include/grgl/common.h
@@ -165,6 +165,8 @@ inline std::size_t hash_combine(std::size_t hash1, std::size_t hash2) {
 
 // Optional: set if the GRG has individual IDs, otherwise it is unset.
 constexpr uint64_t GRG_FLAG_HAS_INDIV_IDS = 0x1;
+// Set if the GRG contains unphased data.
+constexpr uint64_t GRG_FLAG_UNPHASED = 0x2;
 
 constexpr uint64_t GRG_FILE_MAGIC = 0xE9366C64DDC8C5B0;
 constexpr uint16_t GRG_FILE_MAJOR_VERSION = 5;

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -82,9 +82,10 @@ public:
         DEFAULT_NODE_CAPACITY = 1024,
     };
 
-    explicit GRG(size_t numSamples, uint16_t ploidy)
+    explicit GRG(size_t numSamples, uint16_t ploidy, const bool phased = true)
         : m_numSamples(numSamples),
-          m_ploidy(ploidy) {
+          m_ploidy(ploidy),
+          m_phased(phased) {
         release_assert(numSamples % ploidy == 0);
     }
 
@@ -117,6 +118,15 @@ public:
      * @return The ploidy, usually 1 or 2. Individual coalescence support only works when ploidy==2.
      */
     uint16_t getPloidy() const { return m_ploidy; }
+
+    /**
+     * Is the dataset phased?
+     *
+     * If not, GRG still represents the data as a mapping between mutations and haploid samples, but
+     * you cannot depend on any haplotype-based analyses representing the true haplotypes. Individual-based
+     * analyses are still completely accurate.
+     */
+    bool isPhased() const { return m_phased; }
 
     /**
      * Returns true if nodes are ordered in bottom-up topological order.
@@ -545,6 +555,7 @@ protected:
 
     const size_t m_numSamples;
     const uint16_t m_ploidy;
+    const bool m_phased;
 
     // True if the mutationId order matches the (position, allele) order.
     bool m_mutsAreOrdered{false};
@@ -572,8 +583,11 @@ public:
      * @param[in] (Optional) the initial capacity of the node vector. If you know in advance roughly
      *      how many nodes will be created this can improve performance.
      */
-    explicit MutableGRG(size_t numSamples, uint16_t ploidy, size_t initialNodeCapacity = DEFAULT_NODE_CAPACITY)
-        : GRG(numSamples, ploidy) {
+    explicit MutableGRG(size_t numSamples,
+                        uint16_t ploidy,
+                        bool phased = true,
+                        size_t initialNodeCapacity = DEFAULT_NODE_CAPACITY)
+        : GRG(numSamples, ploidy, phased) {
         if (initialNodeCapacity < numSamples) {
             initialNodeCapacity = numSamples * 2;
         }
@@ -717,8 +731,8 @@ using LazyCSREdges32 = CSRStorageImm<LazyFileVector, uint32_t, true, true>;
 
 class CSRGRG : public GRG {
 public:
-    explicit CSRGRG(size_t numSamples, size_t nodeCount, uint16_t ploidy, bool loadUpEdges = true)
-        : GRG(numSamples, ploidy),
+    explicit CSRGRG(size_t numSamples, size_t nodeCount, uint16_t ploidy, bool loadUpEdges = true, bool phased = true)
+        : GRG(numSamples, ploidy, phased),
           m_downEdges(nodeCount),
           m_upEdges(loadUpEdges ? nodeCount : 0) {}
 

--- a/include/grgl/mut_iterator.h
+++ b/include/grgl/mut_iterator.h
@@ -114,7 +114,7 @@ protected:
     virtual void reset_specific() = 0;
 
     // A buffer of loaded mutations from the current position/variant.
-    std::list<MutationAndSamples> m_alreadyLoaded;
+    std::vector<MutationAndSamples> m_alreadyLoaded;
 
     // Range to use.
     IntRange m_genomeRange;

--- a/src/grg_helpers.h
+++ b/src/grg_helpers.h
@@ -93,6 +93,7 @@ static inline void dumpStats(const GRGPtr& grg, const bool calculateNaiveEdges =
     std::cout << "Samples: " << grg->numSamples() << std::endl;
     std::cout << "Mutations: " << grg->getMutations().size() << std::endl;
     std::cout << "Ploidy: " << grg->getPloidy() << std::endl;
+    std::cout << "Phased: " << (grg->isPhased() ? "true" : "false") << std::endl;
     std::cout << "Populations: " << grg->getPopulations().size() << std::endl;
     std::cout << "Range of mutations: " << grg->getBPRange().first << " - " << grg->getBPRange().second << std::endl;
     std::cout << "Specified range: " << grg->getSpecifiedBPRange().first << " - " << grg->getSpecifiedBPRange().second

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -310,6 +310,13 @@ PYBIND11_MODULE(_grgl, m) {
         .def_property_readonly("ploidy", &grgl::GRG::getPloidy, R"^(
                 The ploidy of each individual.
             )^")
+        .def_property_readonly("is_phased", &grgl::GRG::isPhased, R"^(
+                Is the dataset phased?
+
+                If not, GRG still represents the data as a mapping between mutations and haploid samples, but
+                you cannot depend on any haplotype-based analyses representing the true haplotypes. Individual-based
+                analyses are still completely accurate.
+            )^")
         .def_property_readonly("bp_range", &grgl::GRG::getBPRange, R"^(
                 The range in base-pair positions that this GRG covers, from its list of mutations.
 

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -358,7 +358,7 @@ simplifyAndSerialize(const GRGPtr& grg, std::ostream& outStream, const GRGOutput
         static_cast<uint64_t>(grg->numEdges()),
         filter.isSpecified() ? filter.bpRange.first : grg->getSpecifiedBPRange().first,
         filter.isSpecified() ? filter.bpRange.second : grg->getSpecifiedBPRange().second,
-        0, /* Flags */
+        !grg->isPhased() ? GRG_FLAG_UNPHASED : 0, /* Flags */
         0,
         0,
         0,
@@ -554,7 +554,8 @@ MutableGRGPtr readMutableGrg(IFSPointer& inStream) {
     assert_deserialization(header.ploidy != 0, "Malformed GRG file: ploidy was 0");
 
     // Construct GRG and allocate all the nodes.
-    MutableGRGPtr grg = std::make_shared<MutableGRG>(header.sampleCount, header.ploidy, header.nodeCount);
+    MutableGRGPtr grg = std::make_shared<MutableGRG>(
+        header.sampleCount, header.ploidy, !hasFlag(header, GRG_FLAG_UNPHASED), header.nodeCount);
     grg->setSpecifiedBPRange({header.rangeStart, header.rangeEnd});
     grg->makeNode(header.nodeCount - header.sampleCount);
     release_assert(grg->numNodes() == header.nodeCount);
@@ -600,7 +601,8 @@ GRGPtr readImmutableGrg(IFSPointer& inStream, bool loadUpEdges) {
     assert_deserialization(header.ploidy != 0, "Malformed GRG file: ploidy was 0");
 
     // Construct GRG and allocate all the nodes.
-    CSRGRGPtr grg = std::make_shared<CSRGRG>(header.sampleCount, header.nodeCount, header.ploidy, loadUpEdges);
+    CSRGRGPtr grg = std::make_shared<CSRGRG>(
+        header.sampleCount, header.nodeCount, header.ploidy, loadUpEdges, !hasFlag(header, GRG_FLAG_UNPHASED));
     grg->setSpecifiedBPRange({header.rangeStart, header.rangeEnd});
 
     const size_t edgeBytes = readScalar<uint64_t>(*inStream);


### PR DESCRIPTION
An unphased GRG is identical to a phased GRG, except that the is_phased flag is set to False, and the haplotypes cannot be interpreted. Individual-based computations (e.g., matmul() with by_individual=True) should be identical between phased and unphased graphs.

Right now, some limitations:
1. Construction is slow. We stick all heterozygous alleles on the first copies of the individual, which makes the haplotypes not very similar across samples.
2. Similarly, the size of the GRG can be large. An unphased GRG can be up to 5x larger than the phased GRG for the same data.
3. BGEN is not supported for unphased input. The way the encode the data is complex, so deferring for now.