### PR TITLE
Make save_subset() more robust to misspecified filters

### DIFF
--- a/src/grg_helpers.h
+++ b/src/grg_helpers.h
@@ -142,15 +142,19 @@ saveGRG(const GRGPtr& theGRG, const std::string& filename, bool allowSimplify = 
     return grgl::writeGrg(theGRG, outStream, allowSimplify);
 }
 
-static inline void saveGRGSubset(const GRGPtr& theGRG,
+static inline bool saveGRGSubset(const GRGPtr& theGRG,
                                  const std::string& filename,
                                  const TraversalDirection direction,
                                  const NodeIDList& seedList,
                                  std::pair<BpPosition, BpPosition> bpRange = {}) {
-    std::ofstream outStream(filename, std::ios::binary);
     GRGOutputFilter filter(direction, seedList);
     filter.bpRange = bpRange;
+    if (seedList.empty()) {
+        return false;
+    }
+    std::ofstream outStream(filename, std::ios::binary);
     grgl::simplifyAndSerialize(theGRG, outStream, filter, true);
+    return true;
 }
 
 /**

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -678,6 +678,9 @@ PYBIND11_MODULE(_grgl, m) {
         :param bp_range: A pair of integers specifying the base-pair range that this GRG covers. This is just
             meta-data, and does not change the filtering behavior.
         :type bp_range: Tuple[int, int]
+        :return: Whether the output graph was created. If the resulting GRG would be empty (no mutations, or
+            no samples) then it will not save the graph.
+        :rtype: bool
     )^");
 
     m.def("grg_from_trees",

--- a/test/endtoend/test_modify.py
+++ b/test/endtoend/test_modify.py
@@ -29,12 +29,13 @@ class TestGrgModify(unittest.TestCase):
 
     def test_downsample(self):
         sub_grg_filename = "test.downsample.grg"
-        pygrgl.save_subset(
+        saved = pygrgl.save_subset(
             self.grg,
             sub_grg_filename,
             pygrgl.TraversalDirection.UP,
             list(range(0, 200, 10)),
         )
+        self.assertTrue(saved)
         sub_grg = pygrgl.load_immutable_grg(sub_grg_filename)
         self.assertEqual(sub_grg.num_mutations, self.grg.num_mutations)
         self.assertEqual(sub_grg.num_samples, 20)
@@ -51,6 +52,17 @@ class TestGrgModify(unittest.TestCase):
 
         self.assertEqual(acount_full.shape, acount_sub.shape)
         numpy.testing.assert_array_equal(acount_full, acount_sub)
+
+    def test_downsample_fail(self):
+        sub_grg_filename = "test.downsample.fail.grg"
+        saved = pygrgl.save_subset(
+            self.grg,
+            sub_grg_filename,
+            pygrgl.TraversalDirection.DOWN,
+            [],
+        )
+        self.assertFalse(saved)
+        self.assertFalse(os.path.isfile(sub_grg_filename))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously if you gave an empty filter list, it would just copy the GRG. Now it does nothing, and returns False.