### PR TITLE
Add helpers grg.shape and grg.haploid_shape

### DIFF
--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -13,7 +13,7 @@ Python API
     :members: __init__, position, allele, ref_allele, time
 
 .. autoclass:: pygrgl.GRG
-    :members: is_sample, num_samples, num_individuals, ploidy, bp_range, specified_bp_range, nodes_are_ordered, mutations_are_ordered, num_nodes, num_edges, num_up_edges, num_down_edges, get_down_edges, get_up_edges, get_sample_nodes, get_root_nodes, get_node_mutation_pairs, get_mutation_node_pairs, get_mutations_for_node, get_mutation_by_id, set_mutation_by_id, node_has_mutations, add_population, get_populations, add_mutation, num_mutations, get_population_id, set_population_id, get_num_individual_coals, set_num_individual_coals, has_individual_ids, clear_individual_ids, add_individual_id, get_individual_id
+    :members: is_sample, num_samples, num_individuals, shape, haploid_shape, ploidy, bp_range, specified_bp_range, nodes_are_ordered, mutations_are_ordered, num_nodes, num_edges, num_up_edges, num_down_edges, get_down_edges, get_up_edges, get_sample_nodes, get_root_nodes, get_node_mutation_pairs, get_mutation_node_pairs, get_mutations_for_node, get_mutation_by_id, set_mutation_by_id, node_has_mutations, add_population, get_populations, add_mutation, num_mutations, get_population_id, set_population_id, get_num_individual_coals, set_num_individual_coals, has_individual_ids, clear_individual_ids, add_individual_id, get_individual_id
 
 .. autoclass:: pygrgl.MutableGRG
     :members: make_node, connect, disconnect, merge

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -260,6 +260,16 @@ sharedFrontier(const grgl::GRGPtr& grg, grgl::TraversalDirection direction, cons
     return std::move(visitor.m_frontier);
 }
 
+std::pair<size_t, size_t>
+grgShape(const grgl::GRGPtr& grg) {
+    return {grg->numIndividuals(), grg->numMutations()};
+}
+
+std::pair<size_t, size_t>
+grgHapShape(const grgl::GRGPtr& grg) {
+    return {grg->numSamples(), grg->numMutations()};
+}
+
 PYBIND11_MODULE(_grgl, m) {
     py::class_<grgl::Mutation>(m, "Mutation")
         .def(py::init<double, std::string, const std::string&, double>(),
@@ -306,6 +316,14 @@ PYBIND11_MODULE(_grgl, m) {
                 The number of individuals in the GRG. The corresponding samples can be found by
                 multiplying the individual index :math:`I` by the ploidy:
                 :math:`(ploidy * I) + 0, (ploidy \times I) + 1, ..., (ploidy \times I) + (ploidy - 1)`
+            )^")
+        .def_property_readonly("shape", &grgShape, R"^(
+                Get the tuple (num_individuals, num_mutations), which is the shape of the genotype matrix
+                represented by the GRG.
+            )^")
+        .def_property_readonly("haploid_shape", &grgHapShape, R"^(
+                Get the tuple (num_samples, num_mutations), which is the shape of the haploid genotype matrix
+                (0, 1 matrix) represented by the GRG.
             )^")
         .def_property_readonly("ploidy", &grgl::GRG::getPloidy, R"^(
                 The ploidy of each individual.

--- a/test/endtoend/test_basic.py
+++ b/test/endtoend/test_basic.py
@@ -153,6 +153,7 @@ class TestGrgBasic(unittest.TestCase):
         self.assertEqual(grg.num_mutations, self.grg.num_mutations)
         self.assertFalse(grg.is_phased)
         self.assertTrue(self.grg.is_phased)
+        self.assertEqual(grg.shape, (self.grg.num_individuals, self.grg.num_mutations))
 
         shape = (1, grg.num_samples)
         from_igd = pygrgl.matmul(grg, np.ones(shape), pygrgl.TraversalDirection.UP)


### PR DESCRIPTION
Useful for when treating a GRG like a matrix. The default direction is assumed to be "UP", which means the matrix is NxM.