### PR TITLE
Make the progress bar updates much more smooth

### DIFF
--- a/pygrgl/clicmd/construct.py
+++ b/pygrgl/clicmd/construct.py
@@ -380,7 +380,7 @@ def from_tabular(args):
         with Pool(args.jobs) as pool:
             list(
                 tqdm.tqdm(
-                    pool.imap(
+                    pool.imap_unordered(
                         star_build_grg,
                         [
                             (


### PR DESCRIPTION
Using `imap_unordered` updates the progress based on the next part that finishes, whether it is in order or not. This makes the update much more smooth (before it would update in a big chunk if there was a slow one in the middle)