### PR TITLE
Increase number of supported edge to >trillions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,16 @@ Construction for small datasets (such as those included as tests in this reposit
 ## Usage (Python API)
 
 See the provided [jupyter notebooks](https://github.com/aprilweilab/grgl/tree/main/jupyter) and [GettingStarted.md](https://github.com/aprilweilab/grgl/blob/main/GettingStarted.md) for more examples.
+
+
+## Limits
+
+| Quantity | Limit |
+| -------- | ----- |
+| Haploid samples | 2,147,483,646 |
+| Total nodes | 2,147,483,646 |
+| Total mutations (variants) | 4,294,967,294 |
+| Total edges | 18,446,744,073,709,551,615 |
+| Edges to/from a single node | 4,294,967,295 |
+
+_Note_: Node limits can theoretically be expanded to about a trillion, by turning off the `COMPACT_NODE_IDS` preprocessor flag, but this mode is not well tested.

--- a/include/grgl/common.h
+++ b/include/grgl/common.h
@@ -170,7 +170,7 @@ constexpr uint64_t GRG_FLAG_UNPHASED = 0x2;
 
 constexpr uint64_t GRG_FILE_MAGIC = 0xE9366C64DDC8C5B0;
 constexpr uint16_t GRG_FILE_MAJOR_VERSION = 5;
-constexpr uint16_t GRG_FILE_MINOR_VERSION = 1;
+constexpr uint16_t GRG_FILE_MINOR_VERSION = 2;
 
 #pragma pack(push, 1)
 struct GRGFileHeader {

--- a/include/grgl/csr_storage.h
+++ b/include/grgl/csr_storage.h
@@ -368,7 +368,7 @@ public:
         m_nodeIndexes.resize(numNodes + 1);
     }
 
-    explicit CSRStorageImm(EagerFileVector<NodeIDSizeT> nodeIndexes,
+    explicit CSRStorageImm(EagerFileVector<EdgeSizeT> nodeIndexes,
                            EdgeVect<uint8_t> nodeBuckets,
                            size_t numValues,
                            bool reverse = false)
@@ -562,7 +562,7 @@ protected:
     VByteDispatcher<IType, Encoded, Sorted> m_dispatch;
 
     // For N nodes, this vector has N elements. Each element is an index into the buckets
-    EagerFileVector<NodeIDSizeT> m_nodeIndexes;
+    EagerFileVector<EdgeSizeT> m_nodeIndexes;
     EdgeVect<uint8_t> m_nodeBuckets;
     size_t m_numNodes;
     size_t m_appendIndex;

--- a/include/grgl/file_vector.h
+++ b/include/grgl/file_vector.h
@@ -309,6 +309,15 @@ protected:
     const size_t m_bufferAmount;
 };
 
+template <typename T> EagerFileVector<uint64_t> convertTo64BitFV(EagerFileVector<T>& vect) {
+    EagerFileVector<uint64_t> result;
+    result.resize(vect.size(), 0);
+    for (size_t i = 0; i < vect.size(); i++) {
+        result.ref(i) = vect[i];
+    }
+    return std::move(result);
+}
+
 } // namespace grgl
 
 #endif

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -577,7 +577,7 @@ protected:
     bool m_mutsAreOrdered{false};
 
     friend void readGrgCommon(const GRGFileHeader& header, const GRGPtr& grg, IFSPointer& inStream);
-    friend std::pair<NodeIDSizeT, size_t>
+    friend std::pair<NodeIDSizeT, EdgeSizeT>
     simplifyAndSerialize(const GRGPtr& grg, std::ostream& outStream, const GRGOutputFilter& filter, bool allowSimplify);
 
     // Google-test unit tests that need private/protected access.

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -649,6 +649,11 @@ public:
      */
     NodeID makeNode(const size_t count = 1, bool forceOrdered = false) {
         const auto nextId = this->m_nodes.size();
+        if (nextId + count > MAX_GRG_NODES) {
+            std::stringstream ssErr;
+            ssErr << "Cannot create more than " << MAX_GRG_NODES << " nodes in a GRG";
+            throw ApiMisuseFailure(ssErr.str().c_str());
+        }
         for (size_t i = 0; i < count; i++) {
             this->m_nodes.push_back(std::make_shared<GRGNode>());
         }

--- a/include/grgl/grgnode.h
+++ b/include/grgl/grgnode.h
@@ -46,6 +46,8 @@
 
 namespace grgl {
 
+using EdgeSizeT = uint64_t;
+
 #ifdef COMPACT_NODE_IDS
 using NodeID = uint32_t;
 using NodeIDSizeT = uint32_t;

--- a/include/grgl/serialize.h
+++ b/include/grgl/serialize.h
@@ -46,14 +46,14 @@ using IFSPointer = std::shared_ptr<std::istream>;
  * @param[in] grg The GRG to be serialized.
  * @param[in] out The (binary) output stream.
  */
-std::pair<NodeIDSizeT, size_t> writeGrg(const GRGPtr& grg, std::ostream& out, bool allowSimplify = true);
+std::pair<NodeIDSizeT, EdgeSizeT> writeGrg(const GRGPtr& grg, std::ostream& out, bool allowSimplify = true);
 
 class GRGOutputFilter;
 
-std::pair<NodeIDSizeT, size_t> simplifyAndSerialize(const GRGPtr& grg,
-                                                    std::ostream& outStream,
-                                                    const GRGOutputFilter& filter,
-                                                    bool allowSimplify = true);
+std::pair<NodeIDSizeT, EdgeSizeT> simplifyAndSerialize(const GRGPtr& grg,
+                                                       std::ostream& outStream,
+                                                       const GRGOutputFilter& filter,
+                                                       bool allowSimplify = true);
 
 /**
  * Deserialize the GRG from the given input stream.

--- a/src/fast_build.cpp
+++ b/src/fast_build.cpp
@@ -451,7 +451,7 @@ MutableGRGPtr buildTree(HapWindowContext& context,
         const auto& hapVect2 = context.sampleHapVects.at(node2);
         size_t dist = 0;
         assert(hapVect1.size() == hapVect2.size());
-        assert(hapVect1.size() == windowInfo.size());
+        assert(hapVect1.size() == context.windowInfo.size());
         for (size_t i = 0; i < hapVect1.size(); i++) {
             dist += context.windowInfo[i].getDistance(hapVect1[i], hapVect2[i]);
         }
@@ -666,7 +666,7 @@ MutableGRGPtr buildTree(HapWindowContext& context,
         std::vector<NodeIDList> mutIndexToNodes(context.allMutations.size());
         for (const NodeID rootId : result->getRootNodes()) {
             size_t haps = 0;
-            assert(nodeToIndivs.find(rootId) != nodeToIndivs.end());
+            assert(nodeToIndivs.find(rootId) != nodeToIndivs.end() || rootId < numSamples);
             std::vector<size_t> mutIndices = hapsToMutIndices(context.sampleHapVects[rootId], context.windowInfo);
             DEBUG_PRINT("Root " << rootId << " has " << mutIndices.size() << " mutations\n");
             for (const size_t mutIndex : mutIndices) {
@@ -891,7 +891,7 @@ MutableGRGPtr fastGRGFromSamples(const std::string& filePrefix,
 #ifndef NDEBUG
     size_t _ignore_debug = 0;
     MutationAndSamples mutAndSamples;
-    assert(!mutIterator->next(mutAndSamples, _ignore));
+    assert(!mutIterator->next(mutAndSamples, _ignore_debug));
 #endif
 
 #ifdef DEBUG_SANITY_CHECKS

--- a/src/grg.cpp
+++ b/src/grg.cpp
@@ -143,7 +143,8 @@ void GRG::visitDfs(GRGVisitor& visitor, TraversalDirection direction, const Node
             }
             bool keepGoing = visitor.visit(sharedThis, nodeId, direction, DFS_PASS_THERE);
             if (keepGoing) {
-                auto successors = (direction == DIRECTION_UP) ? this->getUpEdges(nodeId) : this->getDownEdges(nodeId);
+                const auto& successors =
+                    (direction == DIRECTION_UP) ? this->getUpEdges(nodeId) : this->getDownEdges(nodeId);
                 for (const auto& succId : successors) {
                     lifo.push_back(succId);
                 }

--- a/src/grg_helpers.h
+++ b/src/grg_helpers.h
@@ -136,7 +136,7 @@ static inline GRGPtr loadImmutableGRG(const std::string& filename, bool loadUpEd
     return result;
 }
 
-static inline std::pair<NodeIDSizeT, NodeIDSizeT>
+static inline std::pair<NodeIDSizeT, EdgeSizeT>
 saveGRG(const GRGPtr& theGRG, const std::string& filename, bool allowSimplify = true) {
     std::ofstream outStream(filename, std::ios::binary);
     return grgl::writeGrg(theGRG, outStream, allowSimplify);

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -260,15 +260,9 @@ sharedFrontier(const grgl::GRGPtr& grg, grgl::TraversalDirection direction, cons
     return std::move(visitor.m_frontier);
 }
 
-std::pair<size_t, size_t>
-grgShape(const grgl::GRGPtr& grg) {
-    return {grg->numIndividuals(), grg->numMutations()};
-}
+std::pair<size_t, size_t> grgShape(const grgl::GRGPtr& grg) { return {grg->numIndividuals(), grg->numMutations()}; }
 
-std::pair<size_t, size_t>
-grgHapShape(const grgl::GRGPtr& grg) {
-    return {grg->numSamples(), grg->numMutations()};
-}
+std::pair<size_t, size_t> grgHapShape(const grgl::GRGPtr& grg) { return {grg->numSamples(), grg->numMutations()}; }
 
 PYBIND11_MODULE(_grgl, m) {
     py::class_<grgl::Mutation>(m, "Mutation")
@@ -581,7 +575,25 @@ PYBIND11_MODULE(_grgl, m) {
         .export_values();
 
     py::class_<grgl::MutableGRG, std::shared_ptr<grgl::MutableGRG>>(m, "MutableGRG", grgClass)
-        .def(py::init<size_t, size_t>(), R"^()^")
+        .def(py::init<size_t, size_t, bool, size_t>(),
+             py::arg("num_samples"),
+             py::arg("ploidy"),
+             py::arg("phased") = true,
+             py::arg("initial_node_capacity") = 1024,
+             R"^(
+            Construct a MutableGRG with the given number of samples and ploidy.
+
+            :param num_samples: The number of samples in the dataset. Cannot be changed; a new GRG needs to be created
+                if the number of samples changes.
+            :type num_samples: int
+            :param ploidy: The ploidy of each individual.
+            :type ploidy: int
+            :param phased: True if the data is phased, False otherwise. Default: True.
+            :type phased: bool
+            :param initial_node_capacity: Number of nodes to reserve (but not allocate) in memory. If you know how many
+                nodes the graph will have, setting this to that number will speed things up.
+            :type initial_node_capacity: int
+        )^")
         .def("make_node", &grgl::MutableGRG::makeNode, py::arg("count") = 1, py::arg("force_ordered") = false, R"^(
             Create one or more new nodes in the graph.
 
@@ -906,6 +918,7 @@ PYBIND11_MODULE(_grgl, m) {
 
     m.attr("INVALID_NODE") = grgl::INVALID_NODE_ID;
     m.attr("COAL_COUNT_NOT_SET") = grgl::COAL_COUNT_NOT_SET;
+    m.attr("NO_UP_EDGES") = grgl::NO_UP_EDGES;
 
     std::stringstream versionString;
     versionString << GRGL_MAJOR_VERSION << "." << GRGL_MINOR_VERSION;

--- a/test/unit/test_common.cpp
+++ b/test/unit/test_common.cpp
@@ -11,7 +11,7 @@ TEST(Common, FloatRange) {
     ASSERT_TRUE(orig.isUnspecified());
     ASSERT_EQ(orig, orig.normalized(0, 100));
     denorm = orig.denormalized(0, 100);
-    ASSERT_EQ((size_t)orig.start(), denorm.start());
+    ASSERT_EQ(0, denorm.start());
     ASSERT_EQ((size_t)denorm.end(), std::numeric_limits<size_t>::max());
 
     orig = {0, 1000};

--- a/test/unit/test_csr_storage.cpp
+++ b/test/unit/test_csr_storage.cpp
@@ -181,7 +181,7 @@ TEST(CSRStorageImm, Writing) {
     uint64_t valueBytesRd = 0;
     infile->read((char*)&valueBytesRd, sizeof(uint64_t));
     EagerFileVector<uint8_t> edges(infile, sizeof(uint64_t), valueBytesRd);
-    EagerFileVector<uint32_t> nodes(infile, sizeof(uint64_t)+valueBytesRd, numNodes+1);
+    EagerFileVector<uint64_t> nodes(infile, sizeof(uint64_t)+valueBytesRd, numNodes+1);
     CSRStorageImm<EagerFileVector, uint32_t, true, true> compressedRead(
         std::move(nodes), std::move(edges), 0);
     for (size_t i = 0; i < numNodes; i++) {


### PR DESCRIPTION
Backwards-compatible file format change. Previously the CSR arrays were stored with 32-bit indices, which limited the number of edges that a GRG could have. They now use 64-bit indices.

Put some hard constraints around node creation, and add unit tests for these edge cases.