### PR TITLE
Immutable GRGs loaded with no up edges by default

### DIFF
--- a/src/grg_helpers.h
+++ b/src/grg_helpers.h
@@ -109,6 +109,13 @@ static inline void dumpStats(const GRGPtr& grg, const bool calculateNaiveEdges =
     std::cout << "======================" << std::endl;
 }
 
+/**
+ * Load the GRG so that it can be modified, by adding/removing nodes and edges.
+ *
+ * @param[in] filename The file to load.
+ * @param[in] loadUpEdges Whether to load the "up" edges (in addition to the down edges). Default: true.
+ * @return A shared_ptr to the MutableGRG object.
+ */
 static inline MutableGRGPtr loadMutableGRG(const std::string& filename, const bool loadUpEdges = true) {
     MutableGRGPtr result;
     IFSPointer inStream = std::make_shared<std::ifstream>(filename, std::ios::binary);
@@ -125,7 +132,15 @@ static inline MutableGRGPtr loadMutableGRG(const std::string& filename, const bo
     return result;
 }
 
-static inline GRGPtr loadImmutableGRG(const std::string& filename, bool loadUpEdges = true) {
+/**
+ * Load the GRG read-only. Edges and nodes cannot be changed, but the Mutations and other auxiliary
+ * information still can be.
+ *
+ * @param[in] filename The file to load.
+ * @param[in] loadUpEdges Whether to load the "up" edges (in addition to the down edges). Default: false.
+ * @return A shared_ptr to the GRG object.
+ */
+static inline GRGPtr loadImmutableGRG(const std::string& filename, bool loadUpEdges = false) {
     GRGPtr result;
     IFSPointer inStream = std::make_shared<std::ifstream>(filename, std::ios::binary);
     if (!inStream->good()) {
@@ -152,6 +167,8 @@ static inline bool saveGRGSubset(const GRGPtr& theGRG,
                                  const TraversalDirection direction,
                                  const NodeIDList& seedList,
                                  std::pair<BpPosition, BpPosition> bpRange = {}) {
+    api_exc_check(direction == TraversalDirection::DIRECTION_DOWN || theGRG->hasUpEdges(),
+                  "Filtering a GRG by samples (individuals) requires loading the GRG with up edges");
     GRGOutputFilter filter(direction, seedList);
     filter.bpRange = bpRange;
     if (seedList.empty()) {

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -424,6 +424,9 @@ PYBIND11_MODULE(_grgl, m) {
                 :return: The parents of the given node as a list of NodeIDs.
                 :rtype: List[int]
             )^")
+        .def_property_readonly("has_up_edges", &grgl::GRG::hasUpEdges, R"^(
+                Returns true if this graph has loaded up edges. All graphs have down edges.
+            )^")
         .def("get_sample_nodes", &grgl::GRG::getSampleNodes, R"^(
                 Get the NodeIDs for the sample nodes.
 
@@ -728,7 +731,7 @@ PYBIND11_MODULE(_grgl, m) {
     m.def("load_immutable_grg",
           &grgl::loadImmutableGRG,
           py::arg("filename"),
-          py::arg("load_up_edges") = true,
+          py::arg("load_up_edges") = false,
           R"^(
         Load a GRG file from disk. Immutable GRGs are much faster to traverse than mutable
         GRGs and take up less RAM, so this is the preferred method if you are using a GRG
@@ -736,7 +739,7 @@ PYBIND11_MODULE(_grgl, m) {
 
         :param filename: The file to load.
         :type filename: str
-        :param load_up_edges: If False, do not load the graph "up" edges (saves RAM).
+        :param load_up_edges: If True, load both "up" and "down" edges of graph (uses more RAM). Default: False.
         :type load_up_edges: bool
         :return: The GRG.
         :rtype: pygrgl.GRG
@@ -998,6 +1001,7 @@ PYBIND11_MODULE(_grgl, m) {
     m.attr("INVALID_NODE") = grgl::INVALID_NODE_ID;
     m.attr("COAL_COUNT_NOT_SET") = grgl::COAL_COUNT_NOT_SET;
     m.attr("NO_UP_EDGES") = grgl::NO_UP_EDGES;
+    m.attr("POPULATION_UNSPECIFIED") = grgl::POPULATION_UNSPECIFIED;
 
     std::stringstream versionString;
     versionString << GRGL_MAJOR_VERSION << "." << GRGL_MINOR_VERSION;

--- a/test/endtoend/test_basic.py
+++ b/test/endtoend/test_basic.py
@@ -35,7 +35,7 @@ class TestGrgBasic(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.grg_filename = construct_grg("test-200-samples.vcf.gz")
-        cls.grg = pygrgl.load_immutable_grg(cls.grg_filename)
+        cls.grg = pygrgl.load_immutable_grg(cls.grg_filename, load_up_edges=True)
 
     def test_up_edges(self):
         only_down_grg = pygrgl.load_immutable_grg(

--- a/test/endtoend/test_matmul.py
+++ b/test/endtoend/test_matmul.py
@@ -23,6 +23,7 @@ def grg2X(grg: pygrgl.GRG, individual: bool = False):
     result = np.zeros((num_samples, grg.num_mutations))
     muts_above = {}
     for node_id in reversed(range(grg.num_nodes)):
+        assert grg.num_up_edges(node_id) != pygrgl.NO_UP_EDGES
         muts = grg.get_mutations_for_node(node_id)
         ma = []
         if muts:
@@ -41,7 +42,7 @@ class TestMatrixMultiplication(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.grg_filename = construct_grg("test-200-samples.vcf.gz", "test.matmul.grg")
-        cls.grg = pygrgl.load_immutable_grg(cls.grg_filename)
+        cls.grg = pygrgl.load_immutable_grg(cls.grg_filename, load_up_edges=True)
         np.random.seed(42)
         cls.tp_exec = concurrent.futures.ThreadPoolExecutor(max_workers=JOBS)
 

--- a/test/endtoend/test_modify.py
+++ b/test/endtoend/test_modify.py
@@ -1,8 +1,6 @@
-import glob
 import numpy
 import os
 import pygrgl
-import subprocess
 import sys
 import unittest
 
@@ -20,7 +18,7 @@ class TestGrgModify(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.grg_filename = construct_grg("test-200-samples.vcf.gz")
-        cls.grg = pygrgl.load_immutable_grg(cls.grg_filename)
+        cls.grg = pygrgl.load_immutable_grg(cls.grg_filename, load_up_edges=True)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Many operations, including matrix multiplication, do not require up-edges on a GRG. The Mutable graph is still loaded by default with up edges (since the Mutable graph is much less performant in general).