### PR TITLE
Fix assert failure on non-diploid datasets

### DIFF
--- a/src/fast_build.cpp
+++ b/src/fast_build.cpp
@@ -745,7 +745,7 @@ void directMap(MutableGRGPtr& grg, const std::vector<MutationAndSamples>& toBeMa
         for (const NodeID sampleId : pair.samples) {
             grg->connect(mutNode, sampleId);
         }
-        if (grg->getPloidy() == 2) {
+        if (grg->getPloidy() == PLOIDY_COAL_PROP) {
             std::unordered_set<NodeIDSizeT> uncoalescedIndividuals;
             NodeIDSizeT mutNodeCoals =
                 getCoalsForParent(grg, nodeToIndivs, pair.samples, uncoalescedIndividuals, false);

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -207,14 +207,17 @@ private:
 };
 
 size_t calculateMissingCoals(const GRGPtr& grg) {
-    // Mark the relevant nodes.
-    GRGCoalMarkVisitor markVisitor;
-    grg->visitDfs(markVisitor, TraversalDirection::DIRECTION_UP, grg->getSampleNodes());
+    if (grg->getPloidy() == 2) {
+        // Mark the relevant nodes.
+        GRGCoalMarkVisitor markVisitor;
+        grg->visitDfs(markVisitor, TraversalDirection::DIRECTION_UP, grg->getSampleNodes());
 
-    // Traverse them and recalculate coalescence information.
-    GRGCoalCalcVisitor visitor(markVisitor.m_marked);
-    fastCompleteDFS(grg, visitor);
-    return visitor.m_updated;
+        // Traverse them and recalculate coalescence information.
+        GRGCoalCalcVisitor visitor(markVisitor.m_marked);
+        fastCompleteDFS(grg, visitor);
+        return visitor.m_updated;
+    }
+    return 0;
 }
 
 } // namespace grgl


### PR DESCRIPTION
The new Reduce() step shouldn't calculate coalescences for non- diploid datasets.