### PR TITLE
Improve matmul's missingness support

### DIFF
--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -1139,10 +1139,11 @@ void GRG::matrixMultiplication(const IOType* inputMatrix,
             }
             if (missMatrix != nullptr && missingnessNode != INVALID_NODE_ID) {
                 const size_t base = missingnessNode * effectiveInputRows;
-                // Apply the single missing-data value for this mutation to all the node values
-                // associated with the missingness node.
-                matmulPerformIOAddition<NodeValueType, IOType, useBitVector>(
-                    nodeValues.data(), base, missMatrix[mutId], inputRows);
+                for (size_t row = 0; row < inputRows; row++) {
+                    const size_t rowStart = row * inputCols;
+                    matmulPerformIOAddition<NodeValueType, IOType, useBitVector>(
+                        nodeValues.data(), base + row, missMatrix, rowStart + mutId);
+                }
             }
         }
         if (this->nodesAreOrdered()) {
@@ -1214,7 +1215,7 @@ void GRG::matrixMultiplication(const IOType* inputMatrix,
                         // Add the missing-data value for this mutation to the output vector position
                         // associated with the mutation.
                         matmulPerformIOAddition<IOType, NodeValueType, useBitVector>(
-                            missMatrix[mutId], nodeValues.data(), base, inputRows);
+                            missMatrix, rowStart + mutId, nodeValues.data(), base + row);
                     }
                 }
             }

--- a/test/endtoend/test_missing.py
+++ b/test/endtoend/test_missing.py
@@ -1,24 +1,25 @@
-import glob
-import numpy as np
+import numpy
 import os
 import pygrgl
-import subprocess
 import sys
 import unittest
-from typing import List, Dict, Tuple, Optional
 
 JOBS = 4
 CLEANUP = True
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(THIS_DIR)
-from testing_utils import construct_grg
+from testing_utils import construct_grg, grg2X, allele_frequencies
 
 EXPECT_DIR = os.path.join(THIS_DIR, "expect")
 INPUT_DIR = os.path.join(THIS_DIR, "input")
 
 
 class TestGrgMissingData(unittest.TestCase):
+    # Properties of the input data.
+    MISSING_INDIVS = 21
+    MISSING_SAMPLES = 25
+
     @classmethod
     def setUpClass(cls):
         cls.grg_filename = construct_grg("test-200-samples.miss.igd")
@@ -47,8 +48,45 @@ class TestGrgMissingData(unittest.TestCase):
                 assert len(set(ms)) == len(ms)
                 total_miss += len(ms)
                 total_miss_idv += len(set([i // 2 for i in ms]))
-        self.assertEqual(total_miss, 25)
-        self.assertEqual(total_miss_idv, 21)
+        self.assertEqual(total_miss, self.MISSING_SAMPLES)
+        self.assertEqual(total_miss_idv, self.MISSING_INDIVS)
+
+    # Test matmul() support for missing data.
+    def test_mult(self):
+        # X is the explicit genotype matrix, with allele frequency used for missing items. So the
+        # only non-0,1,2 values should be missing items.
+        X = grg2X(self.grg, diploid=True)
+        self.assertEqual(
+            len(numpy.where((X > 0) & (X != 1) & (X != 2))[0]), self.MISSING_INDIVS
+        )
+
+        #### UP direction (AX) ####
+        K = 7
+        rv = numpy.random.standard_normal((K, self.grg.num_individuals))
+        # Multiply genotype matrix with a random matrix.
+        numpy_result = rv @ X
+        # Multiply GRG with the same random matrix.
+        freqs = allele_frequencies(self.grg)
+        M = numpy.zeros((K, self.grg.num_mutations))
+        grg_result = pygrgl.matmul(
+            self.grg, rv, pygrgl.TraversalDirection.UP, by_individual=True, miss=M
+        )
+        # We can adjust the GRG result with the M matrix to get an equivalent result to having
+        # the explicit matrix with missing values set to the mean.
+        numpy.testing.assert_allclose(numpy_result, grg_result + (M * freqs))
+
+        #### DOWN direction (AX^T) ####
+        rv = numpy.random.standard_normal((K, self.grg.num_mutations))
+        # Multiply genotype matrix with a random matrix.
+        numpy_result = rv @ X.T
+        # Multiply GRG with the same random matrix.
+        M = numpy.array([freqs]) * rv
+        grg_result = pygrgl.matmul(
+            self.grg, rv, pygrgl.TraversalDirection.DOWN, by_individual=True, miss=M
+        )
+        # We primed the missingness matrix with M=f_i*input, to weight those results, so our GRG result
+        # should be identical to the explicit matrix result.
+        numpy.testing.assert_allclose(numpy_result, grg_result)
 
     @classmethod
     def tearDownClass(cls):

--- a/test/endtoend/testing_utils.py
+++ b/test/endtoend/testing_utils.py
@@ -1,5 +1,7 @@
 import subprocess
 import os
+import pygrgl
+import numpy
 from typing import Optional
 
 JOBS = 4
@@ -29,3 +31,71 @@ def construct_grg(
         output_file = os.path.basename(input_file) + ".final.grg"
     subprocess.check_call(cmd)
     return output_file
+
+
+def allele_frequencies(grg: pygrgl.GRG) -> numpy.typing.NDArray:
+    with numpy.errstate(divide="raise"):
+        kwargs = {}
+        miss = 0
+        if grg.has_missing_data:
+            miss = numpy.zeros((1, grg.num_mutations), dtype=numpy.int32)
+            kwargs["miss"] = miss
+        else:
+            miss = None
+        counts = pygrgl.matmul(
+            grg,
+            numpy.ones((1, grg.num_samples), dtype=numpy.int32),
+            pygrgl.TraversalDirection.UP,
+            **kwargs,
+        )[0]
+        if miss is None:
+            miss = 0
+        else:
+            miss = miss[0]
+        denominator = grg.num_samples - miss
+        return numpy.divide(
+            counts,
+            denominator,
+            out=numpy.zeros(counts.shape, dtype=numpy.float64),
+            where=(denominator != 0),
+        )
+
+
+# It is important that this only uses down edges, so that we can test against
+# matmul methods which (should) only require down edges.
+def grg2X(grg: pygrgl.GRG, diploid: bool = False):
+    samples = grg.num_individuals if diploid else grg.num_samples
+    result = numpy.zeros((samples, grg.num_mutations))
+    samps_below = [list() for _ in range(grg.num_nodes)]
+    for node_id in range(grg.num_nodes):
+        sb = []
+        if grg.is_sample(node_id):
+            sb.append(node_id)
+        for child_id in grg.get_down_edges(node_id):
+            sb.extend(samps_below[child_id])
+        samps_below[node_id] = sb
+
+        muts = grg.get_mutations_for_node(node_id)
+        if muts:
+            for sample_id in sb:
+                indiv = sample_id // grg.ploidy
+                for mut_id in muts:
+                    if diploid:
+                        result[indiv][mut_id] += 1
+                    else:
+                        result[sample_id][mut_id] = 1
+    # Handle missingness afterwards for simplicity (harder to make mistakes this way).
+    if grg.has_missing_data:
+        freqs = allele_frequencies(grg)
+        for mut_id, mut_node, miss_node in grg.get_mutation_node_miss():
+            if miss_node != pygrgl.INVALID_NODE:
+                for sample_id in samps_below[miss_node]:
+                    if diploid:
+                        indiv = sample_id // grg.ploidy
+                        result[indiv][mut_id] += freqs[mut_id]
+                    else:
+                        assert (
+                            result[sample_id][mut_id] == 0
+                        ), f"{result[sample_id][mut_id]}"
+                        result[sample_id][mut_id] = freqs[mut_id]
+    return result


### PR DESCRIPTION
The "miss=M" parameter is now a matrix that matches the dimension of either the input or the output matrix, depending on the direction of the matmul().

Add an end-to-end test that illustrates how to use this matrix to mimic the explicit genotype matrix with a GRG. With an explicit matrix we commonly set all missing values to the mean, e.g. the allele frequency for the given mutation. Equivalent results can be obtained with the GRG in both directions (UP and DOWN), e.g. AX and AX^T using the "miss=..." parameter.