### PR TITLE
When a GRG has no individual IDs, allow sample->pop mapping

### DIFF
--- a/pygrgl/clicmd/construct.py
+++ b/pygrgl/clicmd/construct.py
@@ -80,7 +80,7 @@ def add_options(subparser):
     subparser.add_argument(
         "--population-ids",
         default=None,
-        help='Format: "filename:fieldname". Read population ids from the given '
+        help='Format: "filename:sample_field:pop_field". Read population ids from the given '
         "tab-separate file, using the given fieldname.",
     )
     subparser.add_argument(


### PR DESCRIPTION
`grg construct --population-ids` previously only allowed as input a mapping between individual identifier (e.g., "SAMP123") and the population descriptor (e.g., "POP_A"). Now it allows for it to map between sample index (0...2N-1) and the population descriptor, when there are no individual identifiers in the GRG.