### PR TITLE
Fix bug with VCF + population ID mapping

### DIFF
--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -712,9 +712,8 @@ public:
         }
     }
 
-    virtual bool isMutable() const {
-        return false;
-    }
+    virtual bool isMutable() const { return false; }
+
 protected:
     void visitTopoNodeOrderedDense(GRGVisitor& visitor, TraversalDirection direction, const NodeIDList& seedList);
     void visitTopoNodeOrderedSparse(GRGVisitor& visitor, TraversalDirection direction, const NodeIDList& seedList);
@@ -987,9 +986,8 @@ public:
      */
     void compact(NodeID nodeId = INVALID_NODE_ID);
 
-    bool isMutable() const override {
-        return true;
-    }
+    bool isMutable() const override { return true; }
+
 private:
     // The list of nodes. The node's position in this vector must match its ID.
     std::vector<GRGNodePtr> m_nodes;

--- a/include/grgl/mut_iterator.h
+++ b/include/grgl/mut_iterator.h
@@ -162,10 +162,15 @@ public:
 protected:
     void buffer_next(size_t& totalSamples) override;
     void reset_specific() override;
+    void getMetadataHelper();
 
 private:
     std::unique_ptr<picovcf::VCFFile> m_vcf;
+    // Metadata we cache.
     size_t m_ploidy{};
+    size_t m_numIndividuals{};
+    bool m_isPhased{};
+
     bool m_needsReset;
 };
 

--- a/src/fast_build.cpp
+++ b/src/fast_build.cpp
@@ -45,7 +45,6 @@
 
 namespace grgl {
 
-
 inline bool hasBSFlag(GrgBuildFlags flags, GrgBuildFlags flag) { return (bool)(flags & flag); }
 
 void addExtraInfoToGRG(MutableGRGPtr& grg,

--- a/src/grgl.cpp
+++ b/src/grgl.cpp
@@ -363,16 +363,16 @@ int main(int argc, char** argv) {
             const size_t iterations = reduceGRGUntil(mutGRG, *reduce, REDUCE_MIN_DROP, REDUCE_FRAC_DROP);
             if (verbose) {
                 std::cout << STREAM_PUID << "Reduced GRG for " << iterations << " iterations in "
-                        << std::chrono::duration_cast<std::chrono::milliseconds>(
-                                std::chrono::high_resolution_clock::now() - reduceStartTime)
-                                .count()
-                        << " ms\n";
+                          << std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 std::chrono::high_resolution_clock::now() - reduceStartTime)
+                                 .count()
+                          << " ms\n";
             }
         } else {
             std::cerr << "WARNING: --reduce used, but GRG is not mutable." << std::endl;
         }
     }
-    
+
     if (showStats) {
         dumpStats(theGRG);
     }

--- a/src/map_mutations.cpp
+++ b/src/map_mutations.cpp
@@ -861,4 +861,3 @@ mapMutations(const MutableGRGPtr& grg, MutationIterator& mutations, bool verbose
 }
 
 } // namespace grgl
-


### PR DESCRIPTION
We now cache the metadata from the VCF files, so we don't have to "go backwards" in the file to rescan it, which was failing before. This only showed up when you tried to build a GRG directly from .vcf.gz and also map population labels to the sample nodes.