### PR TITLE
Improve DFS performance/footprint

### DIFF
--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -475,7 +475,8 @@ public:
 
     /**
      * Visit nodes depth-first, starting at the given nodes and following up or
-     * down edges.
+     * down edges. A node is never visited more than one time in either pass (forward
+     * or backward), unless forwardOnly is true.
      *
      * @param[in] visitor The visitor that will be called back. Typically owns any state
      *      that is being computed.

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -899,7 +899,9 @@ PYBIND11_MODULE(_grgl, m) {
           py::arg("forward_only") = false,
           R"^(
         Get a list of NodeIDs in depth-first-search (DFS) order, starting from the given
-        seeds and traversing in the provided TraversalDirection (up or down).
+        seeds and traversing in the provided TraversalDirection (up or down). A node never
+        appears more than one time, unless forward_only is True.
+
 
         :param grg: The GRG to get nodes for.
         :type grg: pygrgl.GRG or pygrgl.MutableGRG


### PR DESCRIPTION
A few tweaks to how LIFO is encoded that should speed it up and reduce the RAM usage. No longer need the NodeID marker.

There was also a bug in the forward/backward DFS that caused nodes to be visited multiple times in the forward direction, though only once in the backwards. This could slow things down quite a bit.