### PR TITLE
Work in progress: APIs for more substantial graph modifications

### DIFF
--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -123,3 +123,53 @@ identical to a phased GRG: all data is stored at the haploid level, and all samp
 only difference is that :cpp:func:`GRG::isPhased` (:py:attr:`GRG.is_phased`) returns false. It is up to the client code
 to ensure that all calculations are performed at the *individual* level (e.g., with the ``by_individual`` flag to
 :py:meth:`matmul`).
+
+Variations of GRGs
+------------------
+
+The typical GRG that most users/tools will interact with has the following properties:
+
+1. It is immutable (:py:meth:`pygrgl.load_immutable_grg`), meaning the edges and nodes cannot be changed.
+2. The nodes are numbered according to bottom-up topological order. That means a node with ID ``i`` is gauranteed to have all of it's children visited if you visit all nodes with IDs less than ``i``. This can be checked with :py:attr:`pygrgl.GRG.nodes_are_ordered`.
+3. The :py:class:`pygrgl.Mutation`s are numbered in ascending order of ``(position, ref_allele, allele)``. This can be checked with :py:attr:`pygrgl.GRG.mutations_are_ordered`.
+4. The Sample nodes are numbered ``0...(num_samples - 1)``, and are leaves of the graph. This can be checked with :py:attr:`pygrgl.GRG.samples_are_ordered`.
+
+The above are true for any immutable GRG that has been loaded. However, you can (optionally) break the above properties
+by performing modifications to the graph. For example:
+
+* An immutable GRG can still change it's Mutations (just not the nodes/edges of the graph). So if you call :py:meth:`pygrgl.GRG.add_mutation` or :py:meth:`pygrgl.GRG.remove_mutation` then :py:attr:`pygrgl.GRG.mutations_are_ordered` will become ``False``.
+* Changes to mutable GRGs can result in violating the above properties.
+  * :py:meth:`pygrgl.MutableGRG.connect` can affect the node topological ordering (see :py:meth:`pygrgl.MutableGRG.connect` for details). If :py:attr:`pygrgl.GRG.nodes_are_ordered` is ``False``, then you need to use :py:attr:`pygrgl.GRG.get_topo_order` (with ``seed_list=None``) to do the traversal.
+  * :py:meth:`pygrgl.MutableGRG.set_samples` will cause :py:attr:`pygrgl.GRG.samples_are_ordered` to become ``False``. You can no longer rely on the numbering of the samples, but this is not usually impactful, as :py:meth:`pygrgl.GRG.get_sample_nodes` and :py:meth:`pygrgl.GRG.is_sample` abstracts this away anyways.
+
+If you have modified a GRG, you can always get all of these properties back by writing it to disk and reloading it
+as an immutable GRG.
+
+Negative nodes
+~~~~~~~~~~~~~~
+
+"Negative" nodes are just regular nodes in the GRG that have been created with ``grg.make_node(negative=True)``. This tells the GRG
+that the node should be considered from the **bottom** of the graph for it's topological order. Regular nodes are always checked
+against the **top** of the graph. For example:
+
+* We create a regular node with ID ``A``. We attach ``A`` as a parent to an existing node ``B``. This maintains the topological order, because the NodeIDs increase in number, and that matched the topological order (``A`` is a parent of a node with a smaller ID)
+* We create a regular node with ID ``A``. We attach ``A`` as a **child** to an existing node ``B``. This breaks topological order! ``B`` is a smaller NodeID than ``A``, but is its parent.
+* We create a negative node with ID ``A``. We attach ``A`` as a child to an existing node ``B``. This maintains the topological order, as negative nodes are considered "less than" all regular nodes, for topological order.
+
+The actual NodeID returned by :py:meth:`pygrgl.GRG.make_node` is still a positive value. The only thing that makes a node negative is how
+the GRG tracks it internally. Also, when you connect a negative node to another node you must put a negative sign in front of it, like this:
+
+::
+
+    new_node = grg.make_node(negative=True)
+    grg.connect(old_node, -new_node)         # Passed the negation! This keeps the topological order
+    ...
+    grg.get_up_edges(new_node)               # All other GRG APIs use the positive node ID
+
+
+Advantages of immutable GRGs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* An immutable GRG uses 2-3x less RAM than a mutable GRG. 
+* An immutable GRG has a faster matrix multiplication than a mutable GRG.
+* :py:attr:`pygrgl.GRG.nodes_are_ordered` and :py:attr:`pygrgl.GRG.samples_are_ordered` will *always* be true in an immutable GRG.

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -451,7 +451,8 @@ public:
             }
         } else {
             const NodeMutMiss query = {nodeId, 0, 0};
-            auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
+            auto mutIdIt = std::lower_bound(
+                m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
             while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
                 if (std::get<1>(*mutIdIt) != INVALID_MUTATION_ID) {
                     result.push_back(nodeAndMutAndMissToType<T>(*mutIdIt));
@@ -487,7 +488,8 @@ public:
             return false;
         }
         const std::tuple<NodeID, MutationId, NodeID> query = {nodeId, 0, 0};
-        auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
+        auto mutIdIt =
+            std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
         while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
             if (std::get<1>(*mutIdIt) != INVALID_MUTATION_ID) {
                 return true;
@@ -1003,27 +1005,7 @@ public:
 
     bool edgesAreOrdered() const override { return false; }
 
-    NodeIDList getOrderedNodes(TraversalDirection direction) override {
-        // TODO: replace this error with actually using a Visitor here to get the numbering.
-        api_exc_check(nodesAreTopo(), "Nodes are not in topological order; use a Visitor instead");
-        NodeIDList result(numNodes());
-        const size_t numNegative = m_negativeNodes.size();
-        // First, add the negative nodes in reverse order
-        size_t i = 0;
-        for (size_t j = numNegative; j > 0; j--) {
-            result[i++] = m_negativeNodes[j - 1];
-        }
-        if (direction == grgl::TraversalDirection::DIRECTION_DOWN) {
-            auto it = result.rbegin();
-            std::advance(it, numNegative);
-            std::iota(it, result.rend(), 0);
-        } else {
-            auto it = result.begin();
-            std::advance(it, numNegative);
-            std::iota(it, result.end(), 0);
-        }
-        return std::move(result);
-    }
+    NodeIDList getOrderedNodes(TraversalDirection direction) override;
 
     /**
      * Create a new node in the GRG.

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -22,6 +22,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <vector>
 
 #include "grgl/common.h"
@@ -118,11 +119,17 @@ public:
      *
      * @param[in] nodeId The node ID to check.
      */
-    bool isSample(const NodeID nodeId) const { return nodeId < this->m_numSamples; }
+    virtual bool isSample(const NodeID nodeId) const { return nodeId < this->m_numSamples; }
 
-    size_t numSamples() const { return m_numSamples; }
+    /**
+     * The number of samples (haplotypes) in the graph.
+     */
+    virtual NodeIDSizeT numSamples() const { return m_numSamples; }
 
-    size_t numIndividuals() const { return m_numSamples / m_ploidy; }
+    /**
+     * The number of individuals (haplotypes/ploidy) in the graph.
+     */
+    NodeIDSizeT numIndividuals() const { return numSamples() / m_ploidy; }
 
     /**
      * How many haploid samples are there per individual?
@@ -141,9 +148,22 @@ public:
     bool isPhased() const { return m_phased; }
 
     /**
-     * Returns true if nodes are ordered in bottom-up topological order.
+     * Returns true if nodes are ordered by ID in bottom-up topological order.
+     *
+     * This means you can just iterate the node IDs from 0...(numNodes - 1) to
+     * perform a topological traversal.
      */
     virtual bool nodesAreOrdered() const = 0;
+
+    /**
+     * Returns true if nodes are ordered in bottom-up topological order, If this is true
+     * and nodesAreOrdered is false, then you cannot iterate by NodeID (which are
+     * always positive), but you can iterate by using getOrderedNodes().
+     *
+     * Most users will not need this method, unless they are heavily modifying the GRG
+     * (e.g., by adding negative nodes to the graph).
+     */
+    virtual bool nodesAreTopo() const = 0;
 
     /**
      * Number of nodes (including sample nodes) in the graph.
@@ -174,6 +194,12 @@ public:
      * Get list of up edges for a particular node in the graph.
      */
     virtual NodeIDList getUpEdges(NodeID nodeId) = 0;
+
+    /**
+     * Get all of the node IDs in topological order for the given direction (UP means do
+     * the leaves first, DOWN means do the roots first).
+     */
+    virtual NodeIDList getOrderedNodes(TraversalDirection direction) = 0;
 
     /**
      * True if this graph stores up edges, false if only down edges are stored.
@@ -228,9 +254,10 @@ public:
     void setSpecifiedBPRange(std::pair<BpPosition, BpPosition> bpRange) { m_specifiedRange = bpRange; }
 
     /**
-     * Get the NodeIDList for all samples in the graph.
+     * Get the NodeIDList for all samples in the graph, in order of sample ID (from the 0th sample
+     * to the (N-1)th sample, where N is the number of haplotypes).
      */
-    NodeIDList getSampleNodes() const {
+    virtual NodeIDList getSampleNodes() const {
         NodeIDList result;
         for (grgl::NodeID i = 0; i < this->numSamples(); i++) {
             result.push_back(i);
@@ -784,7 +811,7 @@ protected:
     // Sample (individual) identifiers
     CSRStringTable m_individualIds;
 
-    const size_t m_numSamples;
+    const NodeIDSizeT m_numSamples;
     const uint16_t m_ploidy;
     const bool m_phased;
 
@@ -851,10 +878,10 @@ public:
      * @param[in] (Optional) the initial capacity of the node vector. If you know in advance roughly
      *      how many nodes will be created this can improve performance.
      */
-    explicit MutableGRG(size_t numSamples,
+    explicit MutableGRG(NodeIDSizeT numSamples,
                         uint16_t ploidy,
                         bool phased = true,
-                        size_t initialNodeCapacity = DEFAULT_NODE_CAPACITY,
+                        NodeIDSizeT initialNodeCapacity = DEFAULT_NODE_CAPACITY,
                         bool useUpEdges = true)
         : GRG(numSamples, ploidy, phased),
           m_hasUpEdges(useUpEdges) {
@@ -862,12 +889,33 @@ public:
             initialNodeCapacity = numSamples * 2;
         }
         this->m_nodes.reserve(initialNodeCapacity);
-        this->makeNode(numSamples, true);
+        this->makeNode(numSamples);
     }
 
-    bool nodesAreOrdered() const override { return m_nodesAreOrdered; }
+    NodeIDSizeT numSamples() const override {
+        if (m_samplesMapping.empty()) {
+            return GRG::numSamples();
+        }
+        return m_samplesMapping.size();
+    }
 
-    bool& nodesAreOrdered() { return m_nodesAreOrdered; }
+    bool isSample(const NodeID nodeId) const override {
+        if (m_samplesMapping.empty()) {
+            return GRG::isSample(nodeId);
+        }
+        return m_sampleSet.find(nodeId) != m_sampleSet.end();
+    }
+
+    NodeIDList getSampleNodes() const override {
+        if (m_samplesMapping.empty()) {
+            return std::move(GRG::getSampleNodes());
+        }
+        return m_samplesMapping;
+    }
+
+    bool nodesAreOrdered() const override { return m_nodesAreOrdered && m_negativeNodes.empty(); }
+
+    bool nodesAreTopo() const override { return m_nodesAreOrdered; }
 
     size_t numNodes() const override { return m_nodes.size(); }
 
@@ -900,6 +948,28 @@ public:
 
     bool edgesAreOrdered() const override { return false; }
 
+    NodeIDList getOrderedNodes(TraversalDirection direction) override {
+        // TODO: replace this error with actually using a Visitor here to get the numbering.
+        api_exc_check(nodesAreTopo(), "Nodes are not in topological order; use a Visitor instead");
+        NodeIDList result(numNodes());
+        const size_t numNegative = m_negativeNodes.size();
+        // First, add the negative nodes in reverse order
+        size_t i = 0;
+        for (size_t j = numNegative; j > 0; j--) {
+            result[i++] = m_negativeNodes[j - 1];
+        }
+        if (direction == grgl::TraversalDirection::DIRECTION_DOWN) {
+            auto it = result.rbegin();
+            std::advance(it, numNegative);
+            std::iota(it, result.rend(), 0);
+        } else {
+            auto it = result.begin();
+            std::advance(it, numNegative);
+            std::iota(it, result.end(), 0);
+        }
+        return std::move(result);
+    }
+
     /**
      * Create a new node in the GRG.
      *
@@ -908,11 +978,15 @@ public:
      * generate sequential-ID nodes. Use `connect()` to connect the newly created node to other nodes.
      *
      * @param[in] count The number of nodes to create.
-     * @param[in] forceOrdered If true, do not "break" the topological ordering property of the graph if
-     *      it already exists. Use only when you are certain that newly added nodes (and their edges) will
-     *      main topological order.
+     * @param[in] negative For "normal" nodes, the topological order is based on counting up with NodeIDs
+     *      but for negative nodes this is not the case, they count (and build) down. If you set this true,
+     *      the node will be added to a special list of prepended nodes so that the topological order can
+     *      be maintained (via getOrderedNodes()... the integer iteration will no longer work). This does not
+     *      return a negative value for NodeID (it is unsigned), and the NodeID increments just like a
+     *      normal node. It is up to the user to use the NodeID appropriately - which means passing it as
+     *      a negative value to connect() whenever edges are created with it.
      */
-    NodeID makeNode(const size_t count = 1, bool forceOrdered = false) {
+    NodeID makeNode(const size_t count = 1, bool negative = false) {
         const auto nextId = this->m_nodes.size();
         if (nextId + count > MAX_GRG_NODES) {
             std::stringstream ssErr;
@@ -921,9 +995,9 @@ public:
         }
         for (size_t i = 0; i < count; i++) {
             this->m_nodes.push_back(std::make_shared<GRGNode>());
-        }
-        if (!forceOrdered) {
-            this->m_nodesAreOrdered = false;
+            if (negative) {
+                m_negativeNodes.emplace_back(nextId + i);
+            }
         }
         if (this->m_nodes.size() > this->m_numSamples) {
             this->m_nodeData.allocNumCoals((this->m_nodes.size() - this->m_numSamples) + 1);
@@ -941,7 +1015,7 @@ public:
      * @param[in] srcId The ID of the source node.
      * @param[in] tgtId The ID of the target node.
      */
-    void connect(NodeID srcId, NodeID tgtId);
+    void connect(SignedNodeID srcId, SignedNodeID tgtId);
 
     /**
      * Remove a graph edge between two nodes.
@@ -987,14 +1061,37 @@ public:
                std::vector<BpPosition> positionAdjust = {});
 
     /**
+     * Change which nodes in the graph are the sample nodes. These nodes do not need to be leaf nodes,
+     * but they should not be reachable from each other (this is not checked: the user must ensure).
+     *
+     * The order that the NodeIDs are passed in the input list is the order that the samples will be
+     * numbered. So for example, sampleNodes[0] is sample 0, samplesNodes[1] is 1, etc. All methods
+     * that deal with samples will treat them in this order, and when the GRG is written to disk the
+     * nodes will be renumbered such that sampleNodes[0] becomes NodeID=0, and so on.
+     *
+     * @param[in] sampleNodes The ordered list of new sample nodes. This list length must be evenly
+     *  divisible by getPloidy().
+     */
+    void setSamples(const NodeIDList& sampleNodes) {
+        api_exc_check(sampleNodes.size() < numNodes(), "Too many sample nodes");
+        m_samplesMapping.clear();
+        m_sampleSet.clear();
+        m_samplesMapping.shrink_to_fit();
+        m_samplesMapping.reserve(sampleNodes.size());
+        for (const NodeID node : sampleNodes) {
+            api_exc_check(node < numNodes(), "Invalid sample node: " << node);
+            m_samplesMapping.emplace_back(node);
+            m_sampleSet.insert(node);
+        }
+        api_exc_check(m_samplesMapping.size() == m_sampleSet.size(), "Sample nodes must be unique");
+    }
+
+    /**
      * Retrieve a node by ID.
      *
      * @param[in] nodeId The ID of the node in question.
      */
-    GRGNodePtr getNode(const NodeID nodeId) const {
-        const NodeID checkId = removeMarks(nodeId);
-        return this->m_nodes.at(checkId);
-    }
+    GRGNodePtr getNode(const NodeID nodeId) const { return this->m_nodes.at(nodeId); }
 
     std::vector<NodeIDSizeT> topologicalSort(TraversalDirection direction) override;
 
@@ -1011,11 +1108,21 @@ public:
 
     bool isMutable() const override { return true; }
 
+    bool samplesAreOrdered() const override { return m_samplesMapping.empty(); }
+
 private:
+    // Empty, or the map from NodeIDs that correspond to the samples to the "sample ID"
+    // (e.g., the NodeID that it will get when/if the GRG is written to disk).
+    NodeIDSet m_sampleSet;
+    NodeIDList m_samplesMapping;
+
     // The list of nodes. The node's position in this vector must match its ID.
     std::vector<GRGNodePtr> m_nodes;
 
     friend MutableGRGPtr readMutableGrg(IFSPointer&, bool);
+
+    // Negative nodes in the order they were added to the GRG. See makeNode() for details.
+    std::vector<NodeID> m_negativeNodes;
 
     // True if the nodeId order matches the bottom-up topological order.
     bool m_nodesAreOrdered{true};
@@ -1031,6 +1138,8 @@ public:
           m_upEdges(loadUpEdges ? nodeCount : 0) {}
 
     bool nodesAreOrdered() const override { return true; }
+
+    bool nodesAreTopo() const override { return true; }
 
     size_t numNodes() const override { return m_downEdges.numNodes(); }
 
@@ -1064,6 +1173,19 @@ public:
         return std::move(result);
     }
 
+    // For CSRGRG, you can just iterate the nodes in order from 0...(numNodes-1). This function
+    // only exists for the Python API, and also to have an agnostic function if you don't
+    // know (or care) what kind of GRG you have.
+    NodeIDList getOrderedNodes(TraversalDirection direction) override {
+        NodeIDList result(numNodes());
+        if (direction == grgl::TraversalDirection::DIRECTION_DOWN) {
+            std::iota(result.rbegin(), result.rend(), 0);
+        } else {
+            std::iota(result.begin(), result.end(), 0);
+        }
+        return std::move(result);
+    }
+
     std::vector<NodeIDSizeT> topologicalSort(TraversalDirection direction) override;
 
     void visitTopo(GRGVisitor& visitor,
@@ -1084,6 +1206,30 @@ using ConstCSRGRGPtr = std::shared_ptr<const CSRGRG>;
 // This header is just separated out to try to keep grg.h well organized. It contains templated
 // functions/classes that are needed by matrix multiplication.
 #include "internal_mult.h"
+
+template <typename NodeValueType, bool useBitVector>
+inline void matmulSumChildrenDown(GRG* grg,
+                                  const NodeID nodeId,
+                                  std::vector<NodeValueType>& nodeValues,
+                                  const size_t effectiveInputRows) {
+    const size_t base = nodeId * effectiveInputRows;
+    for (NodeID childId : grg->getDownEdges(nodeId)) {
+        const size_t cbase = childId * effectiveInputRows;
+        vectorAdd<NodeValueType, useBitVector>(nodeValues.data(), nodeValues.data(), cbase, base, effectiveInputRows);
+    }
+}
+
+template <typename NodeValueType, bool useBitVector>
+inline void matmulSumChildrenUp(GRG* grg,
+                                const NodeID nodeId,
+                                std::vector<NodeValueType>& nodeValues,
+                                const size_t effectiveInputRows) {
+    const size_t base = nodeId * effectiveInputRows;
+    for (NodeID childId : grg->getDownEdges(nodeId)) {
+        const size_t cbase = childId * effectiveInputRows;
+        vectorAdd<NodeValueType, useBitVector>(nodeValues.data(), nodeValues.data(), base, cbase, effectiveInputRows);
+    }
+}
 
 // Notes on parameter constraints/assumptions (_CALLERS_ must ensure these):
 // * initMatrix and nodeInit match -- the dimensions of the former are defined by the latter
@@ -1118,12 +1264,14 @@ void GRG::matrixMultiplication(const IOType* inputMatrix,
     release_assert(effectiveInputRows % nodesPerElem == 0);
     std::vector<NodeValueType> nodeValues(numNodes() * effectiveInputRows / nodesPerElem);
 
+    api_exc_check(nodeInit == NIE_ZERO || !useBitVector, "Node initialization and bit vector type cannot be mixed");
     switch (nodeInit) {
     case NIE_XTX:
         for (NodeID i = 0; i < numNodes(); i++) {
             const size_t base = i * effectiveInputRows;
+            const NodeIDSizeT coalValue = 2 * this->getNumIndividualCoals(i);
             matmulPerformIOAddition<NodeValueType, IOType, useBitVector>(
-                nodeValues.data(), base, 2 * this->getNumIndividualCoals(i), effectiveInputRows);
+                nodeValues.data(), base, coalValue, effectiveInputRows);
         }
         break;
     case NIE_VECTOR:
@@ -1175,50 +1323,54 @@ void GRG::matrixMultiplication(const IOType* inputMatrix,
         }
         if (this->nodesAreOrdered()) {
             for (NodeID i = numNodes(); i > 0; i--) {
-                const NodeID nodeId = i - 1;
-                const size_t base = nodeId * effectiveInputRows;
-                for (NodeID childId : this->getDownEdges(nodeId)) {
-                    const size_t cbase = childId * effectiveInputRows;
-                    vectorAdd<NodeValueType, useBitVector>(
-                        nodeValues.data(), nodeValues.data(), cbase, base, effectiveInputRows);
-                }
+                matmulSumChildrenDown<NodeValueType, useBitVector>(this, i - 1, nodeValues, effectiveInputRows);
+            }
+        } else if (this->nodesAreTopo()) {
+            for (NodeID nodeId : this->getOrderedNodes(TraversalDirection::DIRECTION_DOWN)) {
+                matmulSumChildrenDown<NodeValueType, useBitVector>(this, nodeId, nodeValues, effectiveInputRows);
             }
         } else {
             ValueSumVisitor<NodeValueType> valueSumVisitor(nodeValues, effectiveInputRows);
             this->visitDfs(valueSumVisitor, DIRECTION_UP, getSampleNodes());
         }
         if (!emitAllNodes) {
+            const NodeIDList& samples = getSampleNodes();
             for (size_t row = 0; row < inputRows; row++) {
                 const size_t rowStart = row * outputCols;
-                for (NodeID sampleId = 0; sampleId < numSamples(); sampleId++) {
-                    const size_t base = sampleId * effectiveInputRows;
-                    assert(rowStart + sampleId < outputSize);
-                    const size_t sampleIndex = byIndividual ? (sampleId / m_ploidy) : sampleId;
+                for (NodeID sampleIdx = 0; sampleIdx < samples.size(); sampleIdx++) {
+                    const NodeID sampleNodeId = samples[sampleIdx];
+                    const size_t srcBase = sampleNodeId * effectiveInputRows; // Node space
+                    assert(rowStart + sampleIdx < outputSize);
+                    const size_t generalSample = byIndividual ? (sampleIdx / m_ploidy) : sampleIdx; // IO space
                     matmulPerformIOAddition<IOType, NodeValueType, useBitVector>(
-                        outputMatrix, rowStart + sampleIndex, nodeValues.data(), base + row);
+                        outputMatrix, rowStart + generalSample, nodeValues.data(), srcBase + row);
                 }
             }
         }
         // Upward, we are calculating "how do the samples impact the mutations?"
     } else {
-        for (NodeID sampleId = 0; sampleId < numSamples(); sampleId++) {
-            assert(sampleId < inputCols);
-            const size_t base = sampleId * effectiveInputRows;
-            const size_t sampleIndex = byIndividual ? (sampleId / m_ploidy) : sampleId;
+        // Copy from the input matrix to the sample node values. The destination is per-sample-node,
+        // and the source is per-sample-index (ID of 0...(N-1) where N is number of haplotypes).
+        const NodeIDList& samples = getSampleNodes();
+        for (NodeID sampleIdx = 0; sampleIdx < samples.size(); sampleIdx++) {
+            const NodeID sampleNodeId = samples[sampleIdx];
+            assert(sampleIdx < inputCols);
+            const size_t destBase = sampleNodeId * effectiveInputRows;
+            const size_t generalSample = byIndividual ? (sampleIdx / m_ploidy) : sampleIdx;
             for (size_t row = 0; row < inputRows; row++) {
                 const size_t rowStart = row * inputCols;
                 matmulPerformIOAddition<NodeValueType, IOType, useBitVector>(
-                    nodeValues.data(), base + row, inputMatrix, rowStart + sampleIndex);
+                    nodeValues.data(), destBase + row, inputMatrix, rowStart + generalSample);
             }
         }
         if (this->nodesAreOrdered()) {
-            for (NodeID nodeId = numSamples(); nodeId < numNodes(); nodeId++) {
-                const size_t base = nodeId * effectiveInputRows;
-                for (NodeID childId : this->getDownEdges(nodeId)) {
-                    const size_t cbase = childId * effectiveInputRows;
-                    vectorAdd<NodeValueType, useBitVector>(
-                        nodeValues.data(), nodeValues.data(), base, cbase, effectiveInputRows);
-                }
+            const NodeID start = this->samplesAreOrdered() ? numSamples() : 0;
+            for (NodeID nodeId = start; nodeId < numNodes(); nodeId++) {
+                matmulSumChildrenUp<NodeValueType, useBitVector>(this, nodeId, nodeValues, effectiveInputRows);
+            }
+        } else if (this->nodesAreTopo()) {
+            for (NodeID nodeId : this->getOrderedNodes(TraversalDirection::DIRECTION_UP)) {
+                matmulSumChildrenUp<NodeValueType, useBitVector>(this, nodeId, nodeValues, effectiveInputRows);
             }
         } else {
             ValueSumVisitor<NodeValueType> valueSumVisitor(nodeValues, effectiveInputRows);

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -386,11 +386,15 @@ public:
      * where the additional NodeID is the missingness node (or INVALID_NODE_ID) associated with this
      * Mutation.
      *
+     * @param[in] allowSort Allow the mutations-to-node mapping to be resorted; if false and the mapping is
+     *      not sorted then an exception will be thrown.
+     *
      * @return An iterator over (NodeID, MutationId) pairs or (NodeID, MutationId, NodeID) tuples,
      *      depending on the function template argument.
      */
-    template <typename T = NodeAndMut> NodeAndMutIterator<T> getNodesAndMutations() {
+    template <typename T = NodeAndMut> NodeAndMutIterator<T> getNodesAndMutations(const bool allowSort = true) {
         if (!m_mutIdsByNodeIdSorted) {
+            api_exc_check(allowSort, "Mutation-to-node mapping needs to be sorted, but the user forbid it.");
             sortMutIdsByNodeID();
         }
         if (!m_mutIdsByNodeId.empty()) {
@@ -399,7 +403,10 @@ public:
         return NodeAndMutIterator<T>(&m_mutIdsByNodeIdAndMiss);
     }
 
-    const Mutation& getMutationById(MutationId mutId) { return m_mutations.cref(mutId); }
+    const Mutation& getMutationById(MutationId mutId) {
+        api_exc_check(mutId < m_mutations.size(), "Invalid MutationID: " << mutId);
+        return m_mutations.cref(mutId);
+    }
 
     void setMutationById(MutationId mutId, Mutation mutation) { m_mutations.atRef(mutId) = std::move(mutation); }
 
@@ -411,7 +418,6 @@ public:
      * @return A vector of either MutationId or GRG::MutAndNode (a std::pair), depending on the template
      *      parameter.
      */
-
     template <typename T = MutationId> std::vector<T> getUnmappedMutations() {
         return getMutationsForNode<T>(INVALID_NODE_ID);
     }
@@ -422,44 +428,73 @@ public:
      * GRG::MutAndNode then the mutation and it's corresponding missingness node will be returned.
      *
      * @param[in] nodeId The node to lookup.
+     * @param[in] allowSort Allow the mutations-to-node mapping to be resorted; if false and the mapping is
+     *      not sorted then an exception will be thrown.
      * @return A vector of either MutationId or GRG::MutAndNode (a std::pair), depending on the template
      *      parameter.
      */
-    template <typename T = MutationId> std::vector<T> getMutationsForNode(const NodeID nodeId) {
+    template <typename T = MutationId>
+    std::vector<T> getMutationsForNode(const NodeID nodeId, const bool allowSort = true) {
         if (!m_mutIdsByNodeIdSorted) {
+            api_exc_check(allowSort, "Mutation-to-node mapping needs to be sorted, but the user forbid it.");
             sortMutIdsByNodeID();
         }
         std::vector<T> result;
         if (!m_mutIdsByNodeId.empty()) {
             const NodeAndMut query = {nodeId, 0};
-            auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query);
+            auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query, NodeAndMutLt());
             while (mutIdIt != m_mutIdsByNodeId.end() && mutIdIt->first == nodeId) {
-                result.push_back(std::move(nodeAndMutToType<T>(*mutIdIt)));
+                if (mutIdIt->second != INVALID_MUTATION_ID) {
+                    result.push_back(std::move(nodeAndMutToType<T>(*mutIdIt)));
+                }
                 mutIdIt++;
             }
         } else {
             const NodeMutMiss query = {nodeId, 0, 0};
-            auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query);
+            auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
             while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
-                result.push_back(nodeAndMutAndMissToType<T>(*mutIdIt));
+                if (std::get<1>(*mutIdIt) != INVALID_MUTATION_ID) {
+                    result.push_back(nodeAndMutAndMissToType<T>(*mutIdIt));
+                }
                 mutIdIt++;
             }
         }
         return std::move(result);
     }
 
-    bool nodeHasMutations(const NodeID nodeId) {
+    /**
+     * Does the node have at least one Mutation associated with it?
+     *
+     * @param[in] nodeId The node to lookup.
+     * @param[in] allowSort Allow the mutations-to-node mapping to be resorted; if false and the mapping is
+     *      not sorted then an exception will be thrown.
+     * @return true if the node has one or more Mutation.
+     */
+    bool nodeHasMutations(const NodeID nodeId, const bool allowSort = true) {
         if (!m_mutIdsByNodeIdSorted) {
+            api_exc_check(allowSort, "Mutation-to-node mapping needs to be sorted, but the user forbid it.");
             sortMutIdsByNodeID();
         }
         if (!m_mutIdsByNodeId.empty()) {
             const std::pair<NodeID, MutationId> query = {nodeId, 0};
-            const auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query);
-            return mutIdIt != m_mutIdsByNodeId.end() && (mutIdIt->first == nodeId);
+            auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query, NodeAndMutLt());
+            while (mutIdIt != m_mutIdsByNodeId.end() && mutIdIt->first == nodeId) {
+                if (mutIdIt->second != INVALID_MUTATION_ID) {
+                    return true;
+                }
+                mutIdIt++;
+            }
+            return false;
         }
         const std::tuple<NodeID, MutationId, NodeID> query = {nodeId, 0, 0};
-        const auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query);
-        return mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId;
+        auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
+        while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
+            if (std::get<1>(*mutIdIt) != INVALID_MUTATION_ID) {
+                return true;
+            }
+            mutIdIt++;
+        }
+        return false;
     }
 
     /**
@@ -475,11 +510,15 @@ public:
         std::vector<T> result;
         if (!m_mutIdsByNodeId.empty()) {
             for (const auto& nodeAndMutId : m_mutIdsByNodeId) {
-                result.emplace_back(std::move(nodeAndMutToRevType<T>(nodeAndMutId)));
+                if (nodeAndMutId.second != INVALID_MUTATION_ID) {
+                    result.emplace_back(std::move(nodeAndMutToRevType<T>(nodeAndMutId)));
+                }
             }
         } else {
             for (const auto& triple : m_mutIdsByNodeIdAndMiss) {
-                result.emplace_back(nodeAndMutAndMissToRevType<T>(triple));
+                if (std::get<1>(triple) != INVALID_MUTATION_ID) {
+                    result.emplace_back(nodeAndMutAndMissToRevType<T>(triple));
+                }
             }
         }
         sortByMutation(result);
@@ -764,6 +803,30 @@ public:
     virtual bool samplesAreOrdered() const { return true; }
 
 protected:
+    struct NodeAndMutLt {
+        bool operator()(const GRG::NodeAndMut& lhs, const GRG::NodeAndMut& rhs) const {
+            if (lhs.first == INVALID_NODE_ID && rhs.first != INVALID_NODE_ID) {
+                return true;
+            }
+            if (lhs.first != INVALID_NODE_ID && rhs.first == INVALID_NODE_ID) {
+                return false;
+            }
+            return lhs < rhs;
+        }
+    };
+
+    struct NodeMutMissLt {
+        bool operator()(const GRG::NodeMutMiss& lhs, const GRG::NodeMutMiss& rhs) const {
+            if (std::get<0>(lhs) == INVALID_NODE_ID && std::get<0>(rhs) != INVALID_NODE_ID) {
+                return true;
+            }
+            if (std::get<0>(lhs) != INVALID_NODE_ID && std::get<0>(rhs) == INVALID_NODE_ID) {
+                return false;
+            }
+            return lhs < rhs;
+        }
+    };
+
     void visitTopoNodeOrderedDense(GRGVisitor& visitor, TraversalDirection direction, const NodeIDList& seedList);
     void visitTopoNodeOrderedSparse(GRGVisitor& visitor, TraversalDirection direction, const NodeIDList& seedList);
     void populateMutMissInfo();
@@ -771,15 +834,7 @@ protected:
     // m_mutIdsByNodeId gets appended to and then sorted periodically or as needed, using this
     // function. We rarely need to lookup Mutations by NodeID while modifying a GRG, so this ends
     // up being about 3x smaller than the previous multimap<> and many times faster.
-    void sortMutIdsByNodeID() {
-        if (!m_mutIdsByNodeId.empty()) {
-            release_assert(m_mutIdsByNodeIdAndMiss.empty());
-            std::sort(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end());
-        } else {
-            std::sort(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end());
-        }
-        m_mutIdsByNodeIdSorted = true;
-    }
+    void sortMutIdsByNodeID();
 
     // Templated helpers for transparently handling the cases where we do or don't have
     // missing data nodes.

--- a/include/grgl/grgnode.h
+++ b/include/grgl/grgnode.h
@@ -51,34 +51,28 @@ using EdgeSizeT = uint64_t;
 #ifdef COMPACT_NODE_IDS
 using NodeID = uint32_t;
 using NodeIDSizeT = uint32_t;
+using SignedNodeID = int32_t;
 
 // We support about 2 billion nodes per graph.
 static constexpr NodeIDSizeT MAX_GRG_NODES = 0x7fffffffU - 1;
 static constexpr NodeID INVALID_NODE_ID = 0x7fffffffU;
-// The upper bit is available for flags.
-static constexpr NodeID GRG_NODE_FLAG_MASK = 0x80000000U;
 
-using NodeMark = NodeID;
-constexpr NodeMark NODE_MARK_1 = 0x80000000U;
+static constexpr NodeID GRG_NODE_IS_NEGATIVE = 0x80000000U;
+static constexpr NodeID GRG_NODE_NEGATIVE_MASK = 0x7fffffffU;
 #else
 using NodeID = uint64_t;
 using NodeIDSizeT = uint64_t;
+using SignedNodeID = int64_t;
 
 // We support about trillion nodes.
-#define MAX_GRG_NODES      (0x000000ffffffffff - 1)
-#define INVALID_NODE_ID    (0x000000ffffffffff)
-// The upper 24 bits are available for flags.
-#define GRG_NODE_FLAG_MASK (0xffffff0000000000)
+static constexpr NodeIDSizeT MAX_GRG_NODES = 0x000000ffffffffff - 1;
+static constexpr NodeID INVALID_NODE_ID = 0x000000ffffffffff;
 
-enum NodeMark {
-    NODE_MARK_1 = 0x0000010000000000,
-    NODE_MARK_2 = 0x0000020000000000,
-    NODE_MARK_3 = 0x0000040000000000,
-    NODE_MARK_4 = 0x0000080000000000,
-};
+static constexpr NodeID GRG_NODE_IS_NEGATIVE = 0x8000000000000000;
+static constexpr NodeID GRG_NODE_NEGATIVE_MASK = 0xffffff0000000000;
 #endif
 
-static_assert((INVALID_NODE_ID & GRG_NODE_FLAG_MASK) == 0, "Invalid masks");
+static_assert((INVALID_NODE_ID & ~GRG_NODE_NEGATIVE_MASK) == 0, "Invalid masks");
 
 using NodeIDList = std::vector<NodeID>;
 using NodeIDSetOrdered = std::set<NodeID>;
@@ -90,16 +84,29 @@ using NodeIDSet = std::unordered_set<NodeID>;
 
 using NodeIDListUPtr = std::unique_ptr<NodeIDList>;
 
-inline NodeID markNodeId(const NodeID nodeId, NodeMark markNum, bool value) {
-    if (value) {
-        return nodeId | markNum;
+// Just on the off case that someone was using this externally (highly, highly unlikely).
+// We used to have a bit that could be stolen generically for marking nodes.
+#define NODE_MARK_1 "THIS IS NO LONGER VALID! The node marks are not part of the public API"
+#define markNodeId  NODE_MARK_1
+#define hasMark     NODE_MARK_1
+#define removeMarks NODE_MARK_1
+
+/**
+ * Negative nodes, or "prepended nodes" are topologically beneath all the positive,
+ * or "regular" nodes. This is useful for when you need to build out a graph beneath
+ * the sample nodes.
+ */
+inline bool nodeIsNegative(const NodeID nodeId) { return (bool)(nodeId & GRG_NODE_IS_NEGATIVE); }
+
+/**
+ * Strip off the negative flag on a NodeID;
+ */
+inline NodeID nodeStripNegative(const NodeID nodeId) {
+    if (nodeIsNegative(nodeId)) {
+        return -nodeId;
     }
-    return nodeId & ~static_cast<NodeID>(markNum);
+    return nodeId;
 }
-
-inline bool hasMark(const NodeID nodeId, NodeMark markNum) { return (nodeId & markNum) > 0; }
-
-inline NodeID removeMarks(const NodeID nodeId) { return nodeId & (~GRG_NODE_FLAG_MASK); }
 
 class MutableGRG;
 

--- a/include/grgl/internal_mult.h
+++ b/include/grgl/internal_mult.h
@@ -13,16 +13,17 @@ public:
                const grgl::TraversalDirection direction,
                const grgl::DfsPass dfsPass) override {
         if (dfsPass != grgl::DfsPass::DFS_PASS_THERE) {
-            const size_t base = nodeId * m_numRows;
             if (direction == DIRECTION_DOWN) {
+                const size_t base = nodeId * m_numRows;
                 for (const auto& child : grg->getDownEdges(nodeId)) {
                     const size_t cbase = child * m_numRows;
-                    vectorAdd<T, false>(&m_nodeValues[0], &m_nodeValues[0], base, cbase, m_numRows);
+                    vectorAdd<T, false>(m_nodeValues.data(), m_nodeValues.data(), base, cbase, m_numRows);
                 }
             } else {
+                const size_t base = nodeId * m_numRows;
                 for (const auto& parent : grg->getUpEdges(nodeId)) {
                     const size_t pbase = parent * m_numRows;
-                    vectorAdd<T, false>(&m_nodeValues[0], &m_nodeValues[0], base, pbase, m_numRows);
+                    vectorAdd<T, false>(m_nodeValues.data(), m_nodeValues.data(), base, pbase, m_numRows);
                 }
             }
         }

--- a/pygrgl/clicmd/construct.py
+++ b/pygrgl/clicmd/construct.py
@@ -24,7 +24,6 @@ from multiprocessing import Pool
 from typing import List, Tuple
 from .common import which, time_call, round_up_to
 
-
 HAP_SEG_LENGTH = 128
 
 
@@ -160,7 +159,9 @@ def add_options(subparser):
         help="Forcing reduction of graph after merge.",
     )
     subparser.add_argument(
-        "--force-map-muts", action="store_true", help="Force the use of the MapMutations algorithm (debug feature).",
+        "--force-map-muts",
+        action="store_true",
+        help="Force the use of the MapMutations algorithm (debug feature).",
     )
 
 
@@ -479,4 +480,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/src/grg.cpp
+++ b/src/grg.cpp
@@ -45,42 +45,40 @@ void GRG::removeMutation(const MutationId mutId, const NodeID nodeId) {
     m_mutations.ref(mutId) = Mutation();
 
     // Remove the node mapping.
-    if (nodeId != INVALID_NODE_ID) {
-        bool deleted = false;
-        if (!m_mutIdsByNodeId.empty()) {
-            const NodeAndMut query = {nodeId, 0};
-            auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query);
-            while (mutIdIt != m_mutIdsByNodeId.end() && mutIdIt->first == nodeId) {
-                if (mutIdIt->second == mutId) {
-                    m_mutIdsByNodeId.erase(mutIdIt);
-                    deleted = true;
-                    break;
-                }
-                mutIdIt++;
+    bool deleted = false;
+    if (!m_mutIdsByNodeId.empty()) {
+        const NodeAndMut query = {nodeId, 0};
+        auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query, NodeAndMutLt());
+        while (mutIdIt != m_mutIdsByNodeId.end() && mutIdIt->first == nodeId) {
+            if (mutIdIt->second == mutId) {
+                mutIdIt->second = INVALID_MUTATION_ID;
+                deleted = true;
+                break;
             }
-        } else {
-            const NodeMutMiss query = {nodeId, 0, 0};
-            auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query);
-            while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
-                if (std::get<1>(*mutIdIt) == mutId) {
-                    m_mutIdsByNodeIdAndMiss.erase(mutIdIt);
-                    deleted = true;
-                    break;
-                }
-                mutIdIt++;
-            }
+            mutIdIt++;
         }
-        api_exc_check(deleted, "Could not find NodeId " << nodeId << " in mutation mapping");
+    } else {
+        const NodeMutMiss query = {nodeId, 0, 0};
+        auto mutIdIt =
+            std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
+        while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
+            if (std::get<1>(*mutIdIt) == mutId) {
+                std::get<1>(*mutIdIt) = INVALID_MUTATION_ID;
+                deleted = true;
+                break;
+            }
+            mutIdIt++;
+        }
     }
+    api_exc_check(deleted, "Could not find NodeId " << nodeId << " in mutation mapping");
     m_mutsAreOrdered = false;
 }
 
 MutationId GRG::addMutation(const Mutation& mutation, const NodeID nodeId, const NodeID missNodeId) {
     const MutationId mutId = m_mutations.size();
     m_mutations.push_back(mutation);
-    if (nodeId != INVALID_NODE_ID) {
-        release_assert(nodeId < this->numNodes());
-    }
+    release_assert(nodeId == INVALID_NODE_ID || nodeId < this->numNodes());
+    bool isSorted = this->m_mutIdsByNodeIdSorted;
     if (m_mutIdsByNodeIdAndMiss.empty() && missNodeId != INVALID_NODE_ID) {
         for (const auto& pair : m_mutIdsByNodeId) {
             m_mutIdsByNodeIdAndMiss.emplace_back(pair.first, pair.second, INVALID_NODE_ID);
@@ -89,11 +87,17 @@ MutationId GRG::addMutation(const Mutation& mutation, const NodeID nodeId, const
         m_mutIdsByNodeId.shrink_to_fit();
     }
     if (!m_mutIdsByNodeIdAndMiss.empty() || missNodeId != INVALID_NODE_ID) {
+        // It may stay sorted if the user is only adding Mutations to newly added nodes.
+        isSorted &= (m_mutIdsByNodeIdAndMiss.empty() ||
+                     (nodeId >= std::get<0>(m_mutIdsByNodeIdAndMiss.back()) && nodeId != INVALID_NODE_ID));
         m_mutIdsByNodeIdAndMiss.emplace_back(nodeId, mutId, missNodeId);
     } else {
+        // It may stay sorted if the user is only adding Mutations to newly added nodes.
+        isSorted &=
+            (m_mutIdsByNodeId.empty() || (nodeId >= m_mutIdsByNodeId.back().first && nodeId != INVALID_NODE_ID));
         this->m_mutIdsByNodeId.emplace_back(nodeId, mutId);
     }
-    this->m_mutIdsByNodeIdSorted = false;
+    this->m_mutIdsByNodeIdSorted = isSorted;
     if (m_mutsAreOrdered) {
         m_mutsAreOrdered = false;
     }
@@ -111,10 +115,12 @@ void GRG::sortMutations() {
             const MutationId newMutId = newMutations.size();
             const MutationId oldMutId = std::get<0>(triple);
             newMutations.push_back(std::move(m_mutations.atRef(oldMutId)));
+            const NodeID& mutNode = std::get<1>(triple);
+            const NodeID& missNode = std::get<2>(triple);
             if (hasMissing) {
-                mutIdsByNodeIdAndMiss.emplace_back(std::get<1>(triple), newMutId, std::get<2>(triple));
+                mutIdsByNodeIdAndMiss.emplace_back(mutNode, newMutId, missNode);
             } else {
-                mutIdsByNodeId.emplace_back(std::get<1>(triple), newMutId);
+                mutIdsByNodeId.emplace_back(mutNode, newMutId);
             }
         }
         m_mutations = std::move(newMutations);
@@ -199,6 +205,44 @@ template <> GRG::MutAndNode GRG::nodeAndMutAndMissToRevType(const GRG::NodeMutMi
 
 template <> GRG::MutNodeMiss GRG::nodeAndMutAndMissToRevType(const GRG::NodeMutMiss& triple) {
     return {std::get<1>(triple), std::get<0>(triple), std::get<2>(triple)};
+}
+
+void GRG::sortMutIdsByNodeID() {
+    if (!m_mutIdsByNodeId.empty()) {
+        release_assert(m_mutIdsByNodeIdAndMiss.empty());
+
+        // FIXME: the m_mutIdsByNodeId and m_mutIdsByNodeIdAndMiss need a better abstraction around
+        // them to avoid this yucky code. First we should convert from std::pair to std::tuple
+        // Compact out the soft-deleted Mutations
+        size_t j = 0;
+        for (size_t i = 0; i < m_mutIdsByNodeId.size(); i++) {
+            if (j != i) {
+                m_mutIdsByNodeId[j] = m_mutIdsByNodeId[i];
+            }
+            if (m_mutIdsByNodeId[i].second != INVALID_MUTATION_ID) {
+                j++;
+            }
+        }
+        m_mutIdsByNodeId.resize(j);
+
+        std::sort(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), NodeAndMutLt());
+    } else {
+
+        // Compact out the soft-deleted Mutations
+        size_t j = 0;
+        for (size_t i = 0; i < m_mutIdsByNodeIdAndMiss.size(); i++) {
+            if (j != i) {
+                m_mutIdsByNodeIdAndMiss[j] = m_mutIdsByNodeIdAndMiss[i];
+            }
+            if (std::get<1>(m_mutIdsByNodeIdAndMiss[i]) != INVALID_MUTATION_ID) {
+                j++;
+            }
+        }
+        m_mutIdsByNodeIdAndMiss.resize(j);
+
+        std::sort(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), NodeMutMissLt());
+    }
+    m_mutIdsByNodeIdSorted = true;
 }
 
 void GRG::visitBfs(GRGVisitor& visitor,

--- a/src/grg.cpp
+++ b/src/grg.cpp
@@ -585,4 +585,33 @@ void MutableGRG::compact(NodeID nodeId) {
     }
 }
 
+NodeIDList MutableGRG::getOrderedNodes(TraversalDirection direction) {
+    // TODO: replace this error with actually using a Visitor here to get the numbering.
+    api_exc_check(nodesAreTopo(), "Nodes are not in topological order; use a Visitor instead");
+    // The "negative" nodes can be interleaved with regular positive nodes in m_nodes (any call
+    // sequence of make_node(negative=true) followed by make_node() yields interleaved IDs)
+    NodeIDList result;
+    result.reserve(numNodes());
+    const size_t numNegative = m_negativeNodes.size();
+    for (auto it = m_negativeNodes.crbegin(); it != m_negativeNodes.crend(); ++it) {
+        result.push_back(*it);
+    }
+    size_t nextNeg = 0;
+    // Positives in ASCENDING ID order (samples first, roots last), skipping negatives.
+    for (NodeID id = 0; id < numNodes(); id++) {
+        if (nextNeg < numNegative && m_negativeNodes[nextNeg] == id) {
+            nextNeg++;
+            continue;
+        }
+        result.push_back(id);
+    }
+    release_assert(nextNeg == numNegative); // We better have seen all of the negative nodes!
+    release_assert(result.size() == numNodes());
+    // The DOWN direction is just the reverse of the list that we created for UP
+    if (direction == grgl::TraversalDirection::DIRECTION_DOWN) {
+        vectReverse(result);
+    }
+    return std::move(result);
+}
+
 } // namespace grgl

--- a/src/grg.cpp
+++ b/src/grg.cpp
@@ -260,8 +260,7 @@ void GRG::visitDfs(GRGVisitor& visitor, TraversalDirection direction, const Node
                     lifo.emplace_back(succId, 1);
                 }
             }
-            // Second (back up) pass.
-        } else {
+        } else { // Second (back up) pass.
             assert(visitedForward.at(nodeId));
             assert(nodeAndPass.second == 2);
             lifo.pop_back();
@@ -270,10 +269,16 @@ void GRG::visitDfs(GRGVisitor& visitor, TraversalDirection direction, const Node
     }
 }
 
-void MutableGRG::connect(const NodeID srcId, const NodeID tgtId) {
-    m_nodes.at(srcId)->addDownEdge(tgtId);
+void MutableGRG::connect(SignedNodeID srcId, SignedNodeID tgtId) {
+    // Check topological order conditions before stripping off negative part of NodeID.
+    if (this->m_nodesAreOrdered && srcId <= tgtId) {
+        this->m_nodesAreOrdered = false;
+    }
+    const NodeID src = nodeStripNegative((NodeID)srcId);
+    const NodeID tgt = nodeStripNegative((NodeID)tgtId);
+    m_nodes.at(src)->addDownEdge(tgt);
     if (m_hasUpEdges) {
-        m_nodes.at(tgtId)->addUpEdge(srcId);
+        m_nodes.at(tgt)->addUpEdge(src);
     }
 }
 

--- a/src/grg_helpers.h
+++ b/src/grg_helpers.h
@@ -56,8 +56,14 @@ inline const char* getProcessUniqueID() { return (const char*)&PROCESS_UNIQUE[0]
 #define STREAM_PUID "[" << grgl::getProcessUniqueID() << "] "
 
 inline void fastCompleteDFS(const GRGPtr& grg, GRGVisitor& visitor) {
+    // The visitor expects the direction to be "DOWN" (because a DFS goes down from the roots),
+    // but the actual traversal direction is "UP" in topological order (which DFS gives us).
     if (grg->nodesAreOrdered()) {
         for (grgl::NodeID i = 0; i < grg->numNodes(); i++) {
+            visitor.visit(grg, i, grgl::TraversalDirection::DIRECTION_DOWN, grgl::DfsPass::DFS_PASS_BACK_AGAIN);
+        }
+    } else if (grg->nodesAreTopo()) {
+        for (grgl::NodeID i : grg->getOrderedNodes(grgl::TraversalDirection::DIRECTION_UP)) {
             visitor.visit(grg, i, grgl::TraversalDirection::DIRECTION_DOWN, grgl::DfsPass::DFS_PASS_BACK_AGAIN);
         }
     } else {

--- a/src/map_mutations.cpp
+++ b/src/map_mutations.cpp
@@ -651,7 +651,7 @@ static NodeIDList processCandidateSet(const MutableGRGPtr& grg,
     BitVecCoverageSet coalTrackingSet{grg->numSamples(), batchBitCount};
     BitVecCoverageSet coverageSet{grg->numSamples(), batchBitCount};
 
-    const NodeID mutNodeId = grg->makeNode(1, true);
+    const NodeID mutNodeId = grg->makeNode(1);
     if (!newMutation.isMissing()) {
         grg->addMutation(newMutation, mutNodeId, missingnessNode);
     } else {

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -459,12 +459,17 @@ PYBIND11_MODULE(_grgl, m) {
                 :return: The list of NodeIDs that are root nodes.
                 :rtype: List[int]
             )^")
-        .def("get_node_mutation_pairs", &grgl::GRG::getNodesAndMutations<grgl::GRG::NodeAndMut>, R"^(
+        .def("get_node_mutation_pairs",
+             &grgl::GRG::getNodesAndMutations<grgl::GRG::NodeAndMut>,
+             py::arg("allow_sort") = true,
+             R"^(
                 Get a list of pairs (NodeID, MutationID). Each Mutation typically
                 is associated to a single Node, but rarely it can have more than one
                 Node, in which case it will show up in more than one pair.
                 Results are ordered by NodeID, ascending.
 
+                :param allow_sort: Allow the mutations-to-node mapping to be resorted; if false and the
+                    mapping is not sorted then an exception will be thrown.
                 :return: A list of pairs of NodeID and MutationID.
                 :rtype: List[Tuple[int, int]]
             )^")
@@ -477,12 +482,17 @@ PYBIND11_MODULE(_grgl, m) {
                 :return: A list of pairs of MutationID and NodeID.
                 :rtype: List[Tuple[int, int]]
             )^")
-        .def("get_node_mutation_miss", &grgl::GRG::getNodesAndMutations<grgl::GRG::NodeMutMiss>, R"^(
+        .def("get_node_mutation_miss",
+             &grgl::GRG::getNodesAndMutations<grgl::GRG::NodeMutMiss>,
+             py::arg("allow_sort") = true,
+             R"^(
                 Get a list of triples (NodeID, MutationID, "missingness" NodeID). Each
                 Mutation typically is associated to a single Node, but rarely it can
                 have more than one Node, in which case it will show up in more than one row.
                 Results are ordered by NodeID, ascending.
 
+                :param allow_sort: Allow the mutations-to-node mapping to be resorted; if false and the
+                    mapping is not sorted then an exception will be thrown.
                 :return: A list of tuples of (NodeID, MutationID, "missingness" NodeID).
                 :rtype: List[Tuple[int, int, int]]
             )^")
@@ -495,23 +505,32 @@ PYBIND11_MODULE(_grgl, m) {
                 :return: A list of tuples of (MutationID, NodeID, "missingness" NodeID).
                 :rtype: List[Tuple[int, int, int]]
             )^")
-        .def("get_mutations_for_node", &grgl::GRG::getMutationsForNode<grgl::MutationId>, py::arg("node_id"), R"^(
+        .def("get_mutations_for_node",
+             &grgl::GRG::getMutationsForNode<grgl::MutationId>,
+             py::arg("node_id"),
+             py::arg("allow_sort") = true,
+             R"^(
                 Get all the (zero or more) Mutations associated with the given NodeID.
 
                 :param node_id: The NodeID to get mutations for.
                 :type node_id: int
+                :param allow_sort: Allow the mutations-to-node mapping to be resorted; if false and the
+                    mapping is not sorted then an exception will be thrown.
                 :return: A list of MutationIDs.
                 :rtype: List[int]
             )^")
         .def("get_muts_and_miss_for_node",
              &grgl::GRG::getMutationsForNode<std::pair<grgl::MutationId, grgl::NodeID>>,
              py::arg("node_id"),
+             py::arg("allow_sort"),
              R"^(
                 Get all the (zero or more) Mutations associated with the given NodeID, and for
                 each Mutation the associated missingness node.
 
                 :param node_id: The NodeID to get mutations for.
                 :type node_id: int
+                :param allow_sort: Allow the mutations-to-node mapping to be resorted; if false and the
+                    mapping is not sorted then an exception will be thrown.
                 :return: A list of pairs, (MutationID, NodeID) where the NodeID is for the missingness node.
                 :rtype: List[Tuple[int, int]]
             )^")
@@ -534,12 +553,14 @@ PYBIND11_MODULE(_grgl, m) {
                 :type: pygrgl.Mutation
             )^")
 
-        .def("node_has_mutations", &grgl::GRG::nodeHasMutations, py::arg("node_id"), R"^(
+        .def("node_has_mutations", &grgl::GRG::nodeHasMutations, py::arg("node_id"), py::arg("allow_sort") = true, R"^(
                 Return true if there is one or more Mutations associated with the given
                 NodeID.
 
                 :param node_id: The NodeID to check for mutations.
                 :type node_id: int
+                :param allow_sort: Allow the mutations-to-node mapping to be resorted; if false and the
+                    mapping is not sorted then an exception will be thrown.
                 :return: True if the node has at least one mutation.
                 :rtype: bool
             )^")
@@ -1127,6 +1148,7 @@ PYBIND11_MODULE(_grgl, m) {
     )^");
 
     m.attr("INVALID_NODE") = grgl::INVALID_NODE_ID;
+    m.attr("INVALID_MUTATION") = grgl::INVALID_MUTATION_ID;
     m.attr("COAL_COUNT_NOT_SET") = grgl::COAL_COUNT_NOT_SET;
     m.attr("NO_UP_EDGES") = grgl::NO_UP_EDGES;
     m.attr("POPULATION_UNSPECIFIED") = grgl::POPULATION_UNSPECIFIED;

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -231,7 +231,7 @@ public:
         return true;
     }
 
-    std::vector<grgl::NodeID> m_nodeIds;
+    grgl::NodeIDList m_nodeIds;
     grgl::DfsPass m_dfsPass;
 };
 
@@ -239,6 +239,7 @@ std::vector<grgl::NodeID> getBfsOrder(const grgl::GRGPtr& grg,
                                       grgl::TraversalDirection direction,
                                       const grgl::NodeIDList& seedList,
                                       ssize_t maxQueueWidth = -1) {
+    api_exc_check(seedList.empty(), "Cannot do a BFS from empty list of seeds");
     NodeNumberingIterator iterator(grgl::DFS_PASS_NONE);
     grg->visitBfs(iterator, direction, seedList, maxQueueWidth);
     return std::move(iterator.m_nodeIds);
@@ -248,6 +249,7 @@ std::vector<grgl::NodeID> getDfsOrder(const grgl::GRGPtr& grg,
                                       grgl::TraversalDirection direction,
                                       const grgl::NodeIDList& seedList,
                                       bool forwardOnly = false) {
+    api_exc_check(seedList.empty(), "Cannot do a DFS from empty list of seeds");
     NodeNumberingIterator iterator(forwardOnly ? grgl::DFS_PASS_THERE : grgl::DFS_PASS_BACK_AGAIN);
     grg->visitDfs(iterator, direction, seedList, forwardOnly);
     return std::move(iterator.m_nodeIds);
@@ -255,6 +257,9 @@ std::vector<grgl::NodeID> getDfsOrder(const grgl::GRGPtr& grg,
 
 std::vector<grgl::NodeID>
 getTopoOrder(const grgl::GRGPtr& grg, grgl::TraversalDirection direction, const grgl::NodeIDList& seedList) {
+    if (seedList.empty()) {
+        return std::move(grg->getOrderedNodes(direction));
+    }
     NodeNumberingIterator iterator(grgl::DFS_PASS_NONE);
     grg->visitTopo(iterator, direction, seedList);
     return std::move(iterator.m_nodeIds);
@@ -445,6 +450,9 @@ PYBIND11_MODULE(_grgl, m) {
                 :return: The list of NodeIDs that are sample nodes.
                 :rtype: List[int]
             )^")
+        .def_property_readonly("samples_are_ordered", &grgl::GRG::samplesAreOrdered, R"^(
+                Returns true if the sample nodes are numbered ``0...(numSamples - 1)``.
+            )^")
         .def("get_root_nodes", &grgl::GRG::getRootNodes, R"^(
                 Get the NodeIDs for nodes that have no up edges: the roots of the GRG.
 
@@ -470,8 +478,8 @@ PYBIND11_MODULE(_grgl, m) {
                 :rtype: List[Tuple[int, int]]
             )^")
         .def("get_node_mutation_miss", &grgl::GRG::getNodesAndMutations<grgl::GRG::NodeMutMiss>, R"^(
-                Get a list of triples (NodeID, MutationID, "missingness" NodeID). Each 
-                Mutation typically is associated to a single Node, but rarely it can 
+                Get a list of triples (NodeID, MutationID, "missingness" NodeID). Each
+                Mutation typically is associated to a single Node, but rarely it can
                 have more than one Node, in which case it will show up in more than one row.
                 Results are ordered by NodeID, ascending.
 
@@ -703,21 +711,43 @@ PYBIND11_MODULE(_grgl, m) {
                 nodes the graph will have, setting this to that number will speed things up.
             :type initial_node_capacity: int
         )^")
-        .def("make_node", &grgl::MutableGRG::makeNode, py::arg("count") = 1, py::arg("force_ordered") = false, R"^(
+        .def("make_node",
+             &grgl::MutableGRG::makeNode,
+             py::arg("count") = 1,
+             py::arg("negative") = false,
+             py::kw_only(),
+             R"^(
             Create one or more new nodes in the graph.
 
             :param count: How many nodes to create (optional, default to 1).
             :type count: int
-            :param force_ordered: Set to True if you are sure adding this node will maintain the topological
-                order of the NodeIDs within the graph.
-            :type count: bool
+            :param negative: Treat this node as a negative node, meaning that it is topologically
+                _before_ any other currently existing node. By default, nodes are "positive", meaning
+                they are topologically _after_ any currently existing node. In both cases (position and
+                negative), you don't have to maintain the topological order, and when you connect edges
+                it will detect whether you have maintained the order or not. If you violate the order,
+                then :py:attr:`nodes_are_ordered` will become False.
+            :type negative: bool
+            :return: The NodeID of the first newly created nodes. If you created ``count`` nodes, then
+                the ``count`` consecutive NodeIDs starting at this returned value correspond to the new nodes.
+            :rtype: int
         )^")
-        .def("connect", &grgl::MutableGRG::connect, py::arg("source"), py::arg("target"), R"^(
-            Add a down edge from source to target, and an up edge from target to source.
+        .def("connect",
+             &grgl::MutableGRG::connect,
+             py::arg("source"),
+             py::arg("target"),
+             R"^(
+            Add a down edge from source to target, and an up edge from target to source. If you create edges
+            that break the topological order of the nodes (where parent node > child node) this will detect
+            it and downstream analyses will have worse performance (:py:attr:`nodes_are_ordered` will become False).
 
-            :param source: The NodeID for the source node (edge starts here).
+            You must pass in the negative of a NodeID for either source or target, if that node has been created
+            as a negative (see make_node()). If you are inconsistent between make_node() and connect(), for
+            negative nodes, then the behavior of the topological order is undefined.
+
+            :param source: The NodeID for the source node (edge starts here). Can be negative.
             :type source: int
-            :param target: The NodeID for the target node (edge ends here).
+            :param target: The NodeID for the target node (edge ends here). Can be negative.
             :type target: int
         )^")
         .def("disconnect", &grgl::MutableGRG::disconnect, py::arg("source"), py::arg("target"), R"^(
@@ -727,6 +757,9 @@ PYBIND11_MODULE(_grgl, m) {
             :type source: int
             :param target: The NodeID for the target node (edge ends here).
             :type target: int
+            :return: Whether the edge was actually deleted. This will only be False if you asked for
+                deletion of a non-existent edge.
+            :rtype: bool
         )^")
         .def("merge",
              &grgl::MutableGRG::merge,
@@ -767,6 +800,19 @@ PYBIND11_MODULE(_grgl, m) {
                 the length of other_grg_files. Each position is an offset that is applied to all Mutation
                 positions in the corresponding GRG, before merging it in.
             :type position_adjust: List[int]
+        )^")
+        .def("set_samples", &grgl::MutableGRG::setSamples, py::arg("sample_nodes"), R"^(
+            Change which nodes in the graph are the sample nodes. These nodes do not need to be leaf nodes,
+            but they should not be reachable from each other (this is not checked: the user must ensure).
+
+            The order that the NodeIDs are passed in the input list is the order that the samples will be
+            numbered. So for example, sampleNodes[0] is sample 0, samplesNodes[1] is 1, etc. All methods
+            that deal with samples will treat them in this order, and when the GRG is written to disk the
+            nodes will be renumbered such that sampleNodes[0] becomes NodeID=0, and so on.
+
+            :param sample_nodes: The ordered list of new sample nodes. This list length must be evenly
+                divisible by getPloidy().
+            :type sample_nodes: List[int]
         )^")
         .def("reduce", &grgl::reduceGRG, R"^(
             Make a single pass over the mutable GRG and reduce the size by building hierarchy where there
@@ -963,7 +1009,8 @@ PYBIND11_MODULE(_grgl, m) {
         :type direction: pygrgl.TraversalDirection
         :param seed_list: The list of NodeIDs that represent the starting place of the traversal. For
             example, if you use pygrgl.GRG.get_sample_nodes() and pygrgl.TraversalDirection.UP then
-            the entire graph will be traversed from bottom to top.
+            the entire graph will be traversed from bottom to top. If you pass in empty list, then all
+            of the roots or leaves of the graph will be used as seeds.
         :type seed_list: List[int]
         :return: The ordered list of NodeIDs.
         :rtype: List[int]

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -241,6 +241,7 @@ std::vector<NodeIDSizeT> calculateCoalsForSamples(const GRGPtr& grg, const NodeI
 
 // Set which samples we want to keep; if never called then we keep all samples.
 NodeIDSizeT RenumberAndWriteVisitor::setKeepSamples(const grgl::GRGPtr& grg, grgl::NodeIDList sampleIDList, bool warn) {
+    // FIXME: this likely doesn't work properly if we setSamples(), needs to be thought through.
     NodeIDSizeT numSamples = 0;
     NodeID prevSampleId = INVALID_NODE_ID;
     std::sort(sampleIDList.begin(), sampleIDList.end());
@@ -394,8 +395,10 @@ bool RenumberAndWriteVisitor::visit(const grgl::GRGPtr& grg,
         if (noSamplesMapped) {
             const NodeIDSizeT numSamples = grg->numSamples();
             m_newSampleCount = numSamples;
-            m_nodeCounter = numSamples;
-            std::iota(m_nodeIdMap.begin(), m_nodeIdMap.begin() + numSamples, 0);
+            m_nodeCounter = 0;
+            for (NodeID sampleNode : grg->getSampleNodes()) {
+                m_nodeIdMap[sampleNode] = m_nodeCounter++;
+            }
             m_revIdMap.resize(grg->numSamples());
             for (NodeID sampleId = 0; sampleId < numSamples; sampleId++) {
                 m_newNodeData.setPopId(sampleId, grg->getPopulationId(nodeId));

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -94,6 +94,7 @@ size_t reduceGRG(const MutableGRGPtr& mutGRG) {
                 for (const NodeID child : sharedList) {
                     release_assert(mutGRG->disconnect(bestSibling, child));
                 }
+                // Add the edge and tell GRG that we broke node ordering
                 mutGRG->connect(bestSibling, node);
                 // node's coalescence is unchanged, but bestSibling no longer coalesces the children that
                 // are beneath node now.
@@ -105,8 +106,6 @@ size_t reduceGRG(const MutableGRGPtr& mutGRG) {
                     release_assert(existingCoals >= nodeCoals);
                     mutGRG->setNumIndividualCoals(bestSibling, existingCoals - nodeCoals);
                 }
-                // Since we didn't create a node, we need to tell the GRG explicitly that we broke node ordering.
-                mutGRG->nodesAreOrdered() = false;
                 removedEdges += sharedList.size();
             }
         }

--- a/src/util.h
+++ b/src/util.h
@@ -270,4 +270,14 @@ inline std::string getTmpDir() {
     return "/tmp";
 }
 
+template <typename T> inline void vectReverse(std::vector<T>& vect) {
+    if (vect.empty()) {
+        return;
+    }
+    size_t j = vect.size() - 1;
+    for (size_t i = 0; i < j; i++, j--) {
+        std::swap(vect[i], vect[j]);
+    }
+}
+
 #endif /* GRGL_UTIL_H */

--- a/test/endtoend/test_modify.py
+++ b/test/endtoend/test_modify.py
@@ -111,6 +111,62 @@ class TestGrgModify(unittest.TestCase):
                 (mut.position, mut.allele),
             )
 
+    def test_set_samples(self):
+        grg = pygrgl.load_mutable_grg(self.grg_filename, load_up_edges=True)
+        self.assertEqual(grg.num_samples, 400)
+        self.assertTrue(grg.samples_are_ordered)
+        # Just remove a couple samples, don't reorder them.
+        grg.set_samples(list(range(50, grg.num_samples)))
+        self.assertEqual(grg.num_samples, 350)
+        self.assertFalse(grg.samples_are_ordered)
+
+        # Do matmul and get the value for sample 10 (which is "old" sample 60)
+        inmat = numpy.ones( (1, grg.num_mutations) )
+        result = pygrgl.matmul(grg, inmat, pygrgl.TraversalDirection.DOWN)[0]
+        old_value = result[10]
+
+        # Now reorder the samples by swapping sample 10 and 11 (60 and 61)
+        new_samples = grg.get_sample_nodes()
+        tmp = new_samples[10]
+        new_samples[10] = new_samples[11]
+        new_samples[11] = tmp
+        grg.set_samples(new_samples)
+        self.assertEqual(grg.num_samples, 350)
+        self.assertFalse(grg.samples_are_ordered)
+
+        # Check that the value followed the node, not the sample "index"!
+        result = pygrgl.matmul(grg, inmat, pygrgl.TraversalDirection.DOWN)[0]
+        wrong_value = result[10]
+        new_value = result[11]
+        self.assertEqual(old_value, new_value)
+        self.assertNotEqual(old_value, wrong_value)
+
+    def test_negative_nodes(self):
+        grg = pygrgl.load_mutable_grg(self.grg_filename, load_up_edges=True)
+        self.assertTrue(grg.nodes_are_ordered)
+
+        regular_new = grg.make_node()
+        self.assertTrue(grg.nodes_are_ordered)
+        grg.connect(regular_new, grg.num_nodes - 2)  # Connect as parent: ok
+        self.assertTrue(grg.nodes_are_ordered)
+
+        negative_new = grg.make_node(negative=True)
+        self.assertFalse(grg.nodes_are_ordered)
+        grg.connect(0, -negative_new)                # Connect negative as child: breaks counting order
+        self.assertFalse(grg.nodes_are_ordered)
+
+        topo_list = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
+        self.assertEqual(len(topo_list), grg.num_nodes)
+        self.assertEqual(topo_list[0], negative_new)
+
+        # Now TRULY break the topological order, which will force the get_topo_order() to run a DFS
+        # and produce a new order
+        negative_new = grg.make_node(negative=True)
+        grg.connect(-negative_new, 10)                # Break the order entirely
+
+        # FIXME: this will barf right now
+        topo_list = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/endtoend/test_modify.py
+++ b/test/endtoend/test_modify.py
@@ -86,7 +86,9 @@ class TestGrgModify(unittest.TestCase):
         # Pick a different random node and add two mutations to it.
         self.assertTrue(grg.num_nodes > 1001)
         new_mut_id1 = grg.add_mutation(pygrgl.Mutation(0, "FAKE ALT", "00"), 500)
-        new_mut_id2 = grg.add_mutation(pygrgl.Mutation(500_000_000, "FAKE ALT2", "002"), 1001)
+        new_mut_id2 = grg.add_mutation(
+            pygrgl.Mutation(500_000_000, "FAKE ALT2", "002"), 1001
+        )
         self.assertNotEqual(new_mut_id1, new_mut_id2)
         self.assertFalse(grg.mutations_are_ordered)
         # The node->mut map should be updated properly as well
@@ -121,7 +123,7 @@ class TestGrgModify(unittest.TestCase):
         self.assertFalse(grg.samples_are_ordered)
 
         # Do matmul and get the value for sample 10 (which is "old" sample 60)
-        inmat = numpy.ones( (1, grg.num_mutations) )
+        inmat = numpy.ones((1, grg.num_mutations))
         result = pygrgl.matmul(grg, inmat, pygrgl.TraversalDirection.DOWN)[0]
         old_value = result[10]
 
@@ -152,7 +154,9 @@ class TestGrgModify(unittest.TestCase):
 
         negative_new = grg.make_node(negative=True)
         self.assertFalse(grg.nodes_are_ordered)
-        grg.connect(0, -negative_new)                # Connect negative as child: breaks counting order
+        grg.connect(
+            0, -negative_new
+        )  # Connect negative as child: breaks counting order
         self.assertFalse(grg.nodes_are_ordered)
 
         topo_list = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
@@ -162,10 +166,104 @@ class TestGrgModify(unittest.TestCase):
         # Now TRULY break the topological order, which will force the get_topo_order() to run a DFS
         # and produce a new order
         negative_new = grg.make_node(negative=True)
-        grg.connect(-negative_new, 10)                # Break the order entirely
+        grg.connect(-negative_new, 10)  # Break the order entirely
 
         # FIXME: this will barf right now
         topo_list = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
+
+    def test_regr_negnodes_matmul(self):
+        """
+        Regression test for the following scenario: load a MutableGRG, add some positive and
+        negative nodes, interleaved (alternating between them). Verify that the topological
+        order produces the correct order (negative nodes first), other newly added nodes last.
+        Verify that DOWN matmul() produces the expected result. Verify that matmul() after
+        set_samples() produces the expected result.
+        """
+        grg = pygrgl.load_mutable_grg(self.grg_filename, load_up_edges=True)
+
+        # Check our order invariant before any changes.
+        topo_up = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
+        topo_down = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.DOWN, [])
+        self.assertEqual(topo_up, list(reversed(topo_down)))
+
+        # Get our original matmul result
+        rand_input = numpy.random.standard_normal((1, grg.num_mutations))
+        orig_product = pygrgl.matmul(grg, rand_input, pygrgl.TraversalDirection.DOWN)[0]
+
+        # Just add two rows of new nodes above the previous roots and below the previous samples.
+        orig_node_ct = grg.num_nodes
+        orig_roots = grg.get_root_nodes()
+        orig_samples = grg.get_sample_nodes()
+
+        above1 = []
+        for r in orig_roots:
+            a = grg.make_node()
+            grg.connect(a, r)
+            above1.append(a)
+
+        below1 = []
+        for s in orig_samples:
+            b = grg.make_node(negative=True)
+            grg.connect(s, -b)
+            below1.append(b)
+
+        above2 = []
+        for r in above1:
+            a = grg.make_node()
+            grg.connect(a, r)
+            above2.append(a)
+
+        below2 = []
+        for s in below1:
+            b = grg.make_node(negative=True)
+            grg.connect(s, -b)
+            below2.append(b)
+
+        self.assertFalse(grg.nodes_are_ordered)
+
+        new_below = len(orig_samples) * 2
+        new_above = len(orig_roots) * 2
+
+        # Compare to our original matmul result. We have not modified the Mutations or Samples,
+        # so this should be identical!
+        product2 = pygrgl.matmul(grg, rand_input, pygrgl.TraversalDirection.DOWN)[0]
+        numpy.testing.assert_allclose(orig_product, product2)
+
+        topo_up = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
+
+        # Correct counts.
+        self.assertEqual(len(topo_up), grg.num_nodes)
+        self.assertEqual(len(topo_up), orig_node_ct + new_above + new_below)
+        # Every node appears only once.
+        self.assertEqual(len(topo_up), len(set(topo_up)))
+        # The new "below" nodes should be at the beginning
+        self.assertEqual(
+            topo_up[:new_below], list(reversed(below2)) + list(reversed(below1))
+        )
+        # The new "above" nodes should be at the end
+        self.assertEqual(topo_up[-new_above:], above1 + above2)
+
+        topo_down = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.DOWN, [])
+        # Correct counts.
+        self.assertEqual(len(topo_down), grg.num_nodes)
+        self.assertEqual(len(topo_down), orig_node_ct + new_above + new_below)
+        # Every node appears only once.
+        self.assertEqual(len(topo_down), len(set(topo_down)))
+        # The new "above" nodes should be at the beginning
+        self.assertEqual(
+            topo_down[:new_above], list(reversed(above2)) + list(reversed(above1))
+        )
+        # The new "below" nodes should be at the end
+        self.assertEqual(topo_down[-new_below:], below1 + below2)
+
+        # The two directions should be equivalent, just opposite orders.
+        self.assertEqual(topo_up, list(reversed(topo_down)))
+
+        # Save our new samples, and verify that this still doesn't change the matmul result.
+        grg.set_samples(below2)
+        self.assertEqual(grg.get_sample_nodes(), below2)
+        product3 = pygrgl.matmul(grg, rand_input, pygrgl.TraversalDirection.DOWN)[0]
+        numpy.testing.assert_allclose(orig_product, product3)
 
 
 if __name__ == "__main__":

--- a/test/unit/common_grgs.h
+++ b/test/unit/common_grgs.h
@@ -10,12 +10,12 @@ using namespace grgl;
 //               |---pn6---|
 //          |--pn4--|   |--pn5--|
 //         s0      s1  s2      s3
-inline MutableGRGPtr depth3BinTree(const bool keepNodeOrder = true) {
+inline MutableGRGPtr depth3BinTree() {
     const size_t nSamples = 4;
     MutableGRGPtr grg = std::make_shared<MutableGRG>(nSamples, 2);
-    NodeID pn4 = grg->makeNode(/*count=*/1, /*forceOrdered=*/keepNodeOrder);
-    NodeID pn5 = grg->makeNode(/*count=*/1, /*forceOrdered=*/keepNodeOrder);
-    NodeID pn6 = grg->makeNode(/*count=*/1, /*forceOrdered=*/keepNodeOrder);
+    NodeID pn4 = grg->makeNode(/*count=*/1);
+    NodeID pn5 = grg->makeNode(/*count=*/1);
+    NodeID pn6 = grg->makeNode(/*count=*/1);
     grg->connect((NodeID)4, (NodeID)0);
     grg->connect((NodeID)4, (NodeID)1);
     grg->connect((NodeID)5, (NodeID)2);
@@ -32,13 +32,13 @@ inline MutableGRGPtr depth3BinTree(const bool keepNodeOrder = true) {
 // pn11 -> (pn8, pn10, s6)
 // pn12 -> (pn10, s5)
 // pn13 -> (pn12, pn9)
-inline MutableGRGPtr sample8Grg(const bool keepNodeOrder = true) {
+inline MutableGRGPtr sample8Grg() {
     const size_t nSamples = 8;
     MutableGRGPtr grg = std::make_shared<MutableGRG>(nSamples, 2);
     // We force this graph to maintain the topological flag, which means we have to ensure
     // we never create an edge from n1->n2 where n1<=n2.
     for (size_t i = 8; i <= 13; i++) {
-        grg->makeNode(/*count=*/1, /*forceOrdered=*/keepNodeOrder);
+        grg->makeNode(/*count=*/1);
     }
     grg->connect((NodeID)8, (NodeID)0);
     grg->connect((NodeID)8, (NodeID)1);

--- a/test/unit/test_grg.cpp
+++ b/test/unit/test_grg.cpp
@@ -12,6 +12,7 @@
 #include "grg_helpers.h"
 
 #include <fstream>
+#include <memory>
 
 namespace grgl {
 
@@ -37,10 +38,18 @@ TEST(GRG, Mutations) {
     }
 }
 
+inline void breakOrder(GRGPtr& grg) {
+    // We can break the topological order by adding a useless node and edge
+    MutableGRGPtr mutGRG = std::dynamic_pointer_cast<MutableGRG>(grg);
+    const NodeID newNodeId = mutGRG->makeNode();
+    mutGRG->connect(grg->numNodes() - 1, newNodeId); // Breaks topo order!
+}
+
 TEST(GRG, DotProductGood) {
-    GRGPtr grg = depth3BinTree(/*keepNodeOrder=*/false);
+    GRGPtr grg = depth3BinTree();
     ASSERT_TRUE(grg->numEdges() == 6);
     ASSERT_TRUE(grg->numNodes() == 7);
+    breakOrder(grg);
     ASSERT_FALSE(grg->nodesAreOrdered());
 
     Mutation m1(5, "A", "G");
@@ -89,9 +98,10 @@ TEST(GRG, DotProductGood) {
 }
 
 TEST(GRG, MatrixMultGood) {
-    GRGPtr grg = depth3BinTree(/*keepNodeOrder=*/false);
+    GRGPtr grg = depth3BinTree();
     ASSERT_TRUE(grg->numEdges() == 6);
     ASSERT_TRUE(grg->numNodes() == 7);
+    breakOrder(grg);
     ASSERT_FALSE(grg->nodesAreOrdered());
 
     Mutation m1(5, "A", "G");
@@ -255,4 +265,150 @@ TEST(GRGHelper, CoalsForParent) {
     ASSERT_EQ(coals3, 0);
     expected = {0, 1, 2, 3};
     ASSERT_EQ(uncoalesced, expected);
+}
+
+TEST(GRG, NegativeNodes) {
+    GRGPtr grg = depth3BinTree();
+    ASSERT_TRUE(grg->numEdges() == 6);
+    ASSERT_TRUE(grg->numNodes() == 7);
+    ASSERT_TRUE(grg->nodesAreOrdered());
+
+    MutableGRGPtr mutGRG = std::dynamic_pointer_cast<MutableGRG>(grg);
+    // We can maintain the topological order if we:
+    // 1: Add a new node and connect it as a parent
+    const NodeID node1 = mutGRG->makeNode();
+    mutGRG->connect(node1, grg->numNodes() - 2);
+    ASSERT_TRUE(grg->nodesAreOrdered());
+    // 2: Add a new "negative" node and connect it as a child
+    // Nodes are no longer ordered by ID, but they are still trivially topologically ordered
+    const NodeID node2 = mutGRG->makeNode(1, /*negative=*/true);
+    mutGRG->connect(0, -node2);
+    ASSERT_FALSE(grg->nodesAreOrdered());
+    ASSERT_TRUE(grg->nodesAreTopo());
+
+    // But we will break it if we add a negative node as a parent!
+    mutGRG->connect(-node2, 3);
+    ASSERT_FALSE(grg->nodesAreTopo());
+
+    // Just check some helper methods
+    const NodeID smallNode = 1;
+    const NodeID bigNode = MAX_GRG_NODES - 1;
+    const NodeID smallNeg = -smallNode;
+    const NodeID bigNeg = -bigNode;
+    // Type casting should work
+    ASSERT_TRUE((SignedNodeID)bigNeg < (SignedNodeID)smallNeg);
+    ASSERT_TRUE(nodeIsNegative(bigNeg));
+    ASSERT_TRUE(nodeIsNegative(smallNeg));
+    ASSERT_FALSE(nodeIsNegative(bigNode));
+    ASSERT_FALSE(nodeIsNegative(smallNode));
+    ASSERT_EQ(nodeStripNegative(bigNeg), bigNode);
+    ASSERT_EQ(nodeStripNegative(smallNeg), smallNode);
+}
+
+TEST(GRG, ChangeSamples) {
+    MutableGRGPtr grg = std::dynamic_pointer_cast<MutableGRG>(depth3BinTree());
+    ASSERT_EQ(grg->numSamples(), 4);
+    ASSERT_EQ(grg->numNodes(), 7);
+    // Lets add some mutations just so we can test matrix multiplication
+    grg->addMutation(Mutation(1, "A", "G"), 6);
+    grg->addMutation(Mutation(2, "T", "G"), 5);
+    grg->addMutation(Mutation(3, "A", "C"), 4);
+    ASSERT_EQ(grg->numMutations(), 3);
+
+    // Create 4 new nodes, beneath the old samples, and turn them into samples.
+    NodeID newest = grg->makeNode(4, /*negative=*/true);
+    ASSERT_EQ(grg->numNodes(), 11);
+    grg->connect(0, -newest);
+    newest++;
+    grg->connect(1, -newest);
+    newest++;
+    grg->connect(2, -newest);
+    newest++;
+    grg->connect(3, -newest);
+    ASSERT_LT(newest, grg->numNodes());
+    // Nodes are no longer ordered according to NodeID, but they are still trivially
+    // topologically ordered.
+    ASSERT_FALSE(grg->nodesAreOrdered());
+    ASSERT_TRUE(grg->nodesAreTopo());
+
+    // Get the old samples
+    NodeIDList expected = {0, 1, 2, 3};
+    ASSERT_EQ(expected, grg->getSampleNodes());
+
+    // Test a matmul with the old samples
+    std::vector<int64_t> inputVect = {11, 41, 37, 73};
+    std::vector<int64_t> outputVect(3);
+    grg->matrixMultiplication<int64_t, int64_t, false>(inputVect.data(), 4, 1, TraversalDirection::DIRECTION_UP, outputVect.data(), 3);
+    const std::vector<int64_t> expectedMat = {162, 110, 52};
+    ASSERT_EQ(expectedMat, outputVect);
+
+    // Make new samples
+    NodeIDList newSamples = {7, 8, 9, 10};
+    ASSERT_EQ(newest, newSamples.back());
+    grg->setSamples(newSamples);
+    ASSERT_EQ(newSamples, grg->getSampleNodes());
+    ASSERT_TRUE(grg->isSample(7));
+    ASSERT_TRUE(grg->isSample(10));
+    ASSERT_FALSE(grg->isSample(0));
+    ASSERT_FALSE(grg->isSample(3));
+
+    // Get the topological order
+    NodeIDList topo = grg->getOrderedNodes(TraversalDirection::DIRECTION_UP);
+    std::vector<bool> saw(grg->numNodes(), false);
+    ASSERT_EQ(topo.size(), grg->numNodes());
+    for (NodeID node : topo) {
+        ASSERT_FALSE(saw.at(node));
+        switch (node) {
+            case 0:
+                ASSERT_TRUE(saw.at(7));
+                break;
+            case 1:
+                ASSERT_TRUE(saw.at(8));
+                break;
+            case 2:
+                ASSERT_TRUE(saw.at(9));
+                break;
+            case 3:
+                ASSERT_TRUE(saw.at(10));
+                break;
+            default:
+                break;
+        }
+        saw.at(node) = true;
+    }
+
+    // Test a matmul with the new samples!
+    outputVect[0] = 0;
+    outputVect[1] = 0;
+    outputVect[2] = 0;
+    grg->matrixMultiplication<int64_t, int64_t, false>(inputVect.data(), 4, 1, TraversalDirection::DIRECTION_UP, outputVect.data(), 3);
+    ASSERT_EQ(expectedMat, outputVect);
+
+    // Now truly break the topological order and ensure that matmul STILL works (it will use
+    // a visitor)
+    grg->connect(grg->numNodes() - 1, grg->makeNode());
+    ASSERT_FALSE(grg->nodesAreTopo());
+    outputVect[0] = 0;
+    outputVect[1] = 0;
+    outputVect[2] = 0;
+    grg->matrixMultiplication<int64_t, int64_t, false>(inputVect.data(), 4, 1, TraversalDirection::DIRECTION_UP, outputVect.data(), 3);
+    ASSERT_EQ(expectedMat, outputVect);
+
+    // Now write this GRG to disk, _WITHOUT_ simplification. Reload it, and we should still get
+    // the same matmul result
+    std::string testFile = "test.change_samples.grg";
+    saveGRG(grg, testFile, /*allowSimplify=*/false);
+    GRGPtr grg2 = loadImmutableGRG(testFile);
+    ASSERT_TRUE(grg2->nodesAreOrdered()); // Serializing re-ordered everything.
+    ASSERT_EQ(grg2->numSamples(), 4);
+    ASSERT_EQ(grg2->numNodes(), 11);
+    outputVect[0] = 0;
+    outputVect[1] = 0;
+    outputVect[2] = 0;
+    grg2->matrixMultiplication<int64_t, int64_t, false>(inputVect.data(), 4, 1, TraversalDirection::DIRECTION_UP, outputVect.data(), 3);
+    ASSERT_EQ(expectedMat, outputVect);
+
+    // Samples should have been renumbered!
+    expected = {0, 1, 2, 3};
+    ASSERT_EQ(expected, grg2->getSampleNodes());
 }

--- a/test/unit/test_util.cpp
+++ b/test/unit/test_util.cpp
@@ -67,3 +67,38 @@ TEST(HapHelpers, bitwiseSubtract) {
     std::vector<size_t> expected = {4, 11, 77, 81};
     ASSERT_EQ(bitsSet, expected);
 }
+
+TEST(Util, vectReverse) {
+    grgl::NodeIDList theVect;
+
+    // Edge case: empty
+    vectReverse(theVect);
+    ASSERT_TRUE(theVect.empty());
+
+    // Edge case: 1 element
+    theVect = {91919191};
+    vectReverse(theVect);
+    ASSERT_EQ(theVect[0], 91919191);
+
+    // Edge case: 2 elements
+    theVect = {1001, 999};
+    vectReverse(theVect);
+    ASSERT_EQ(theVect[0], 999);
+    ASSERT_EQ(theVect[1], 1001);
+
+    // Odd # of elements
+    theVect = {1, 9, 2};
+    vectReverse(theVect);
+    ASSERT_EQ(theVect[0], 2);
+    ASSERT_EQ(theVect[1], 9);
+    ASSERT_EQ(theVect[2], 1);
+
+    // Even # of elements
+    theVect = {100, 66, 87, 33};
+    vectReverse(theVect);
+    ASSERT_EQ(theVect[0], 33);
+    ASSERT_EQ(theVect[1], 87);
+    ASSERT_EQ(theVect[2], 66);
+    ASSERT_EQ(theVect[3], 100);
+
+}


### PR DESCRIPTION
* ImmutableGRG has new API: "set_samples()"
  * Takes an (ordered) list of NodeIDs that will become the new samples in the GRG
  * The user is responsible for ensuring that no pair of nodes in the list have a ancestor/descendant relationship
  * Compatible with get_sample_nodes() and is_sample()
  * You can change the number of samples by giving more nodes
  * New property samples_are_ordered tells you sample nodes are`0...(numSamples-1)`
* ImmutableGRG has new concept of "negative node"
  * "Negative" nodes are just regular nodes in the GRG that have been created with `grg.make_node(negative=True)`
  * Negative nodes are considered "topologically beneath" all regular nodes
  * The actual NodeID returned by make_node() is still a positive value.
  * When you connect a negative node to another node you must put a negative sign in front of it
  * Property `nodes_are_ordered` tells you that you can iterate nodes from `0...(numNodes-1)`
  * Otherwise, you must use `pygrgl.get_topo_order()`, but now you can do so with `seed_list=[]` which will much more efficiently let you traverse the entire graph.
* `matmul` respects negative nodes and new sample nodes.
* `save_grg` respects negative nodes and new sample nodes.
* `save_subset` IS UNTESTED!  And likely not yet correct.
* When you save a GRG with negative nodes and/or new sample nodes, everything gets renumbered. So when you reload the GRG from disk, all nodes are "regular", and the samples will once again be numbered `0...(numSamples-1)`, _in the order that you provided to set_samples_.