### PR TITLE
Some checks around individual coalescent counts

### DIFF
--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -681,6 +681,12 @@ public:
     }
 
     /**
+     * Does this dataset have any individual coalescence information? If not, you won't be
+     * able to quickly get the exact sample variance for each mutation (diploid genotypes only).
+     */
+    bool hasIndividualCoals() const { return m_nodeData.hasCoalCounts(); }
+
+    /**
      * Add the next individual's identifier. Must be called in order, for individuals
      * 0...(N-1).
      *
@@ -1122,8 +1128,11 @@ void GRG::matrixMultiplication(const IOType* inputMatrix,
     case NIE_XTX:
         for (NodeID i = 0; i < numNodes(); i++) {
             const size_t base = i * effectiveInputRows;
+            const NodeIDSizeT coalCount = this->getNumIndividualCoals(i);
+            api_exc_check(coalCount != COAL_COUNT_NOT_SET,
+                          "Coalescent counts not available for this GRG (init=XTX won't work)");
             matmulPerformIOAddition<NodeValueType, IOType, useBitVector>(
-                nodeValues.data(), base, 2 * this->getNumIndividualCoals(i), effectiveInputRows);
+                nodeValues.data(), base, coalCount * 2, effectiveInputRows);
         }
         break;
     case NIE_VECTOR:

--- a/include/grgl/node_data.h
+++ b/include/grgl/node_data.h
@@ -46,6 +46,8 @@ public:
         m_nodeData_popId.ref(nodeId) = popId;
     }
 
+    bool hasCoalCounts() const { return !m_nodeData_numCoals.empty(); }
+
     NodeIDSizeT getNumCoals(const NodeIDSizeT numSamples, NodeID nodeId) {
         if (nodeId < numSamples) {
             return 0;

--- a/pygrgl/clicmd/construct.py
+++ b/pygrgl/clicmd/construct.py
@@ -24,7 +24,6 @@ from multiprocessing import Pool
 from typing import List, Tuple
 from .common import which, time_call, round_up_to
 
-
 HAP_SEG_LENGTH = 128
 
 
@@ -160,7 +159,9 @@ def add_options(subparser):
         help="Forcing reduction of graph after merge.",
     )
     subparser.add_argument(
-        "--force-map-muts", action="store_true", help="Force the use of the MapMutations algorithm (debug feature).",
+        "--force-map-muts",
+        action="store_true",
+        help="Force the use of the MapMutations algorithm (debug feature).",
     )
 
 
@@ -479,4 +480,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -635,6 +635,10 @@ PYBIND11_MODULE(_grgl, m) {
                 :param num_coals: The number of individuals that coalesced, or pygrgl.COAL_COUNT_NOT_SET.
                 :type num_coals: int
             )^")
+        .def_property_readonly("has_individual_coals", &grgl::GRG::hasIndividualCoals, R"^(
+            Does this dataset have any individual coalescence information? If not, you won't be
+            able to quickly get the exact sample variance for each mutation (diploid genotypes only).
+        )^")
         .def_property_readonly("has_individual_ids", &grgl::GRG::hasIndividualIds, R"^(
             True if this GRG has string identifiers for each individual. See get_individual_id().
             )^")

--- a/test/endtoend/test_matmul.py
+++ b/test/endtoend/test_matmul.py
@@ -111,6 +111,7 @@ class TestMatrixMultiplication(unittest.TestCase):
         # Test that (X^t * X) can be computed by setting init properly.
         node_XX_count = [0 for _ in range(self.grg.num_nodes)]
         assert self.grg.ploidy == 2
+        assert self.grg.has_individual_coals
         for node_id in range(self.grg.num_nodes):
             curr_coals = self.grg.get_num_individual_coals(node_id)
             assert curr_coals != pygrgl.COAL_COUNT_NOT_SET

--- a/test/unit/test_grg.cpp
+++ b/test/unit/test_grg.cpp
@@ -5,6 +5,7 @@
 #include "grgl/grgnode.h"
 #include "grgl/mutation.h"
 #include "grgl/serialize.h"
+#include "grgl/transform.h"
 
 #include "common_grgs.h"
 #include "common_visitors.h"
@@ -255,4 +256,37 @@ TEST(GRGHelper, CoalsForParent) {
     ASSERT_EQ(coals3, 0);
     expected = {0, 1, 2, 3};
     ASSERT_EQ(uncoalesced, expected);
+}
+
+TEST(GRG, MatmulXTX) {
+    GRGPtr grg = depth3BinTree();
+    ASSERT_EQ(grg->numSamples(), 4);
+    ASSERT_EQ(grg->numNodes(), 7);
+    // Lets add some mutations just so we can test matrix multiplication
+    grg->addMutation(Mutation(1, "A", "G"), 6);
+    grg->addMutation(Mutation(2, "T", "G"), 5);
+    grg->addMutation(Mutation(3, "A", "C"), 4);
+    ASSERT_EQ(grg->numMutations(), 3);
+    ASSERT_EQ(grg->getPloidy(), 2);
+    ASSERT_FALSE(grg->hasIndividualCoals());
+
+    std::vector<int64_t> inputVect = {1, 1, 1, 1};
+    std::vector<int64_t> outputVect(3);
+
+    // When we don't have coalescence counts, this should fail!
+    auto doMatmul = [&]() {
+        grg->matrixMultiplication<int64_t, int64_t, false>(
+        inputVect.data(), 4, 1, TraversalDirection::DIRECTION_UP, outputVect.data(), 3,
+        false, false, nullptr, grgl::GRG::NIE_XTX, nullptr);
+    };
+    ASSERT_THROW(doMatmul(), grgl::ApiMisuseFailure);
+
+    // Now calculate the coalescences and run again.
+    calculateMissingCoals(grg);
+    outputVect[0] = 0;
+    outputVect[1] = 0;
+    outputVect[2] = 0;
+    doMatmul();
+    std::vector<int64_t> expected = {8, 4, 4};
+    ASSERT_EQ(expected, outputVect);
 }


### PR DESCRIPTION
Make sure we have coal counts before trying to use them in matmul. Expose a Python API for determining whether coal counts exist or not. Add a C++ unit test for matmul(init=xtx).