### PR TITLE
Fix submodule URLs in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,8 @@
 	url = https://github.com/Taywee/args
 [submodule "third-party/pybind11"]
 	path = third-party/pybind11
-	url = ../../pybind/pybind11
+	url = https://github.com/pybind/pybind11
 	branch = stable
 [submodule "third-party/bgen"]
 	path = third-party/bgen
-	url = ../../dcdehaas/bgen
+	url = https://github.com/dcdehaas/bgen


### PR DESCRIPTION
Updated submodule URLs for pybind11 and bgen, so that we can do `uv add "pygrgl @ git+ssh://git@github.com/aprilweilab/grgl.git@main"` in downstream packages.