### PR TITLE
HWE exact p-value calculations in C++, for use via Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ set(GRGL_CORE_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/transform.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/ts2grg.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/windowing.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/third-party/hwe/snp_hwe.cpp
   )
 
 # Add CUDA sources if CUDA is enabled

--- a/doc/ts_convert.rst
+++ b/doc/ts_convert.rst
@@ -76,6 +76,17 @@ position and allele values:
       print(f"GRG ID = {mut_id}, tskit ID = {tsid}")
 
 
+``MutationID`` to ``NodeID`` is a 1-to-1 relationship, and in *constructed* GRGs we only ever create
+a single ``Mutation`` for every unique ``(position, allele, ref_allele)`` triple. However, when converting
+from *tskit* you can have multiple ``Mutation``s for the same ``(position, allele, ref_allele)`` that represents
+either the actual ancestry (two separate mutations, mostly in simulated ARGs) or is just an
+artifact of the ARG inference process (e.g., *tsinfer*). In these cases, you need to adjust
+any relevant calculations (you may *want* to keep separate ``Mutations``).
+
+**TODO**: coming soon, new methods ``pygrgl.MutableGRG.uniquifyMutations`` (which will add new nodes so that the relationship
+is one-to-one) and ``pygrgl.GRG.mutations_are_unique`` (for checking uniqueness).
+
+
 A note about Mutation times
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/grgl/common.h
+++ b/include/grgl/common.h
@@ -207,4 +207,5 @@ template <typename T> inline T roundUpToMultiple(const T input, const T multiple
 
 } // namespace grgl
 
+
 #endif /* GRGL_COMMON_H */

--- a/pygrgl/clicmd/convert.py
+++ b/pygrgl/clicmd/convert.py
@@ -66,6 +66,9 @@ def convert_command(arguments):
                 ' want to construct a .grg from something else try "grg construct"'
             )
             exit(2)
+        if not arguments.ts_coals:
+            print("Warning: no individual (diploid) coalescence information will be calculated unless you specify --ts-coals. "
+                  "This is fine, but downstream applications will need to use approximations for Mutation variance.", file=sys.stderr)
         command_args = [GRGL, arguments.input_file, "-o", arguments.output_file]
         if arguments.binary_muts:
             command_args.append("--binary-muts")

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -37,6 +37,19 @@ namespace py = pybind11;
 #include <iostream>
 #include <sstream>
 
+/**
+ * Hardy-Weinberg equilibrium exact p-value test from Wiggington, et. al., 2025
+ * "A Note on Exact Tests of Hardy-Weinberg Equilibrium". This is a slightly modified
+ * wrapper of the C code from https://csg.sph.umich.edu/abecasis/Exact/.
+ *
+ * @param[in] obs_hets Heterozygote count.
+ * @param[in] obs_homs1 Homozygote count for first allele.
+ * @param[in] obs_homs2 Homozygote count for other alleles.
+ * @return The p-value for the two-sided test.
+ */
+double SNPHWE(int64_t obs_hets, int64_t obs_hom1, int64_t obs_hom2);
+
+
 std::string mutStr(const grgl::Mutation& mut) {
     std::stringstream result;
     result << "<[pygrgl.Mutation] position=" << mut.getPosition() << ", ref_allele=" << mut.getRefAllele()
@@ -1101,6 +1114,21 @@ PYBIND11_MODULE(_grgl, m) {
         :type seeds: List[int]
         :return: A list of node IDs representing the frontier.
         :rtype: List[int]
+    )^");
+
+    m.def("hwe_exact_pv", &SNPHWE, py::arg("hets_A"), py::arg("homs_A"), py::arg("other"), R"^(
+        Hardy-Weinberg equilibrium exact p-value test from Wiggington, et. al., 2025
+        "A Note on Exact Tests of Hardy-Weinberg Equilibrium". This is a slightly modified wrapper
+        of the C code from https://csg.sph.umich.edu/abecasis/Exact/.
+
+        :param hets_A: Number of heterozygotes containing the allele of interest.
+        :type hets_A: int
+        :param homs_A: Number of homozygotes containing the allele of interest.
+        :type homs_A: int
+        :param other: Number of genotypes that do not include the allele of interest at all.
+        :type other: int
+        :return: The p-value for the two-sided test.
+        :rtype: float
     )^");
 
     m.attr("INVALID_NODE") = grgl::INVALID_NODE_ID;

--- a/third-party/hwe/README
+++ b/third-party/hwe/README
@@ -1,0 +1,9 @@
+From https://csg.sph.umich.edu/abecasis/Exact/:
+"The subroutines below implement a fast exact Hardy-Weinberg Equilibrium test for SNPs as described in Wigginton, et al. (2005). This test is based on an efficient algorithm for enumerating the exact heterozygote probability distribution conditional on the number of minor alleles present in the sample. It adequately controls Type I error rates within large and small samples and is suitable for use in large-scale studies of SNP data. With appropriate citation, these routines are freely available for your use and can be incorporated into other programs."
+
+Citation:
+A Note on Exact Tests of Hardy-Weinberg Equilibrium
+Wigginton, Janis E. et al.
+The American Journal of Human Genetics, Volume 76, Issue 5, 887 - 893
+
+https://www.cell.com/AJHG/fulltext/S0002-9297(07)60735-6

--- a/third-party/hwe/snp_hwe.cpp
+++ b/third-party/hwe/snp_hwe.cpp
@@ -1,0 +1,86 @@
+/*
+// This code implements an exact SNP test of Hardy-Weinberg Equilibrium as described in
+// Wigginton, JE, Cutler, DJ, and Abecasis, GR (2005) A Note on Exact Tests of
+// Hardy-Weinberg Equilibrium. American Journal of Human Genetics. 76: 000 - 000
+//
+// Written by Jan Wigginton
+*/
+
+// Modified slightly to C++-ify it by Drew DeHaas:
+// * use std::vector instead of malloc()
+// * throw exceptions instead of exit(), which makes it friendlier for APIs.
+// * change integer types to stdint/size_t
+
+#include <cstdint>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+double SNPHWE(int64_t obs_hets, int64_t obs_hom1, int64_t obs_hom2) {
+    if (obs_hom1 < 0 || obs_hom2 < 0 || obs_hets < 0) {
+        std::stringstream ssErr;
+        ssErr << "HWE received a negative count: " << obs_hets << ", " << obs_hom1 << ", " << obs_hom2;
+        throw std::runtime_error(ssErr.str());
+    }
+
+    int64_t obs_homc = obs_hom1 < obs_hom2 ? obs_hom2 : obs_hom1;
+    int64_t obs_homr = obs_hom1 < obs_hom2 ? obs_hom1 : obs_hom2;
+
+    int64_t rare_copies = 2 * obs_homr + obs_hets;
+    int64_t genotypes = obs_hets + obs_homc + obs_homr;
+
+    std::vector<double> het_probs(rare_copies + 1);
+
+    for (size_t i = 0; i <= rare_copies; i++)
+        het_probs[i] = 0.0;
+
+    /* start at midpoint */
+    int64_t mid = rare_copies * (2 * genotypes - rare_copies) / (2 * genotypes);
+
+    /* check to ensure that midpoint and rare alleles have same parity */
+    if ((rare_copies & 1) ^ (mid & 1))
+        mid++;
+
+    int64_t curr_hets = mid;
+    int64_t curr_homr = (rare_copies - mid) / 2;
+    int64_t curr_homc = genotypes - curr_hets - curr_homr;
+
+    het_probs[mid] = 1.0;
+    double sum = het_probs[mid];
+    for (curr_hets = mid; curr_hets > 1; curr_hets -= 2) {
+        het_probs[curr_hets - 2] =
+            het_probs[curr_hets] * curr_hets * (curr_hets - 1.0) / (4.0 * (curr_homr + 1.0) * (curr_homc + 1.0));
+        sum += het_probs[curr_hets - 2];
+
+        /* 2 fewer heterozygotes for next iteration -> add one rare, one common homozygote */
+        curr_homr++;
+        curr_homc++;
+    }
+
+    curr_hets = mid;
+    curr_homr = (rare_copies - mid) / 2;
+    curr_homc = genotypes - curr_hets - curr_homr;
+    for (curr_hets = mid; curr_hets <= rare_copies - 2; curr_hets += 2) {
+        het_probs[curr_hets + 2] =
+            het_probs[curr_hets] * 4.0 * curr_homr * curr_homc / ((curr_hets + 2.0) * (curr_hets + 1.0));
+        sum += het_probs[curr_hets + 2];
+
+        /* add 2 heterozygotes for next iteration -> subtract one rare, one common homozygote */
+        curr_homr--;
+        curr_homc--;
+    }
+
+    for (size_t i = 0; i <= rare_copies; i++)
+        het_probs[i] /= sum;
+
+    double p_hwe = 0.0;
+    /*  p-value calculation for p_hwe  */
+    for (size_t i = 0; i <= rare_copies; i++) {
+        if (het_probs[i] > het_probs[obs_hets])
+            continue;
+        p_hwe += het_probs[i];
+    }
+
+    p_hwe = p_hwe > 1.0 ? 1.0 : p_hwe;
+    return p_hwe;
+}


### PR DESCRIPTION
Everything I tried to speed up the Python was just too complex and slower, so just wrap the original exact calculations C code in C++ and expose it via Python.

`pygrgl.hwe_exact_pv` is the new API method.