### PR TITLE
Expose __version__ on pygrgl package

### DIFF
--- a/pygrgl/__init__.py
+++ b/pygrgl/__init__.py
@@ -14,3 +14,4 @@
 # You should have received a copy of the GNU General Public License
 # with this program.  If not, see <https://www.gnu.org/licenses/>.
 from .grg import *  # noqa: F401
+from _grgl import __version__  # noqa: F401


### PR DESCRIPTION
## Summary
- `_grgl.__version__` is already set from `GRGL_MAJOR_VERSION`/`GRGL_MINOR_VERSION` in `include/grgl/version.h` (see `src/python/_grgl.cpp:1139-1141`), but `pygrgl/grg.py` uses `from _grgl import *`, which skips dunder names. As a result `pygrgl.__version__` was unset.
- Re-export it explicitly in `pygrgl/__init__.py` so `version.h` is the single source of truth for both `setup.py` and the importable package.

## Test plan
- [ ] `python -c "import pygrgl; print(pygrgl.__version__)"` prints `2.7`
- [ ] `python -c "from pygrgl import __version__; print(__version__)"` prints `2.7`