### PR TITLE
Large performance improvement to GRG modification

### DIFF
--- a/include/grgl/common.h
+++ b/include/grgl/common.h
@@ -207,5 +207,4 @@ template <typename T> inline T roundUpToMultiple(const T input, const T multiple
 
 } // namespace grgl
 
-
 #endif /* GRGL_COMMON_H */

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -372,7 +372,10 @@ public:
         return NodeAndMutIterator<T>(&m_mutIdsByNodeIdAndMiss);
     }
 
-    const Mutation& getMutationById(MutationId mutId) { return m_mutations.cref(mutId); }
+    const Mutation& getMutationById(MutationId mutId) {
+        api_exc_check(mutId < m_mutations.size(), "Invalid MutationID: " << mutId);
+        return m_mutations.cref(mutId);
+    }
 
     void setMutationById(MutationId mutId, Mutation mutation) { m_mutations.atRef(mutId) = std::move(mutation); }
 
@@ -384,7 +387,6 @@ public:
      * @return A vector of either MutationId or GRG::MutAndNode (a std::pair), depending on the template
      *      parameter.
      */
-
     template <typename T = MutationId> std::vector<T> getUnmappedMutations() {
         return getMutationsForNode<T>(INVALID_NODE_ID);
     }
@@ -405,34 +407,58 @@ public:
         std::vector<T> result;
         if (!m_mutIdsByNodeId.empty()) {
             const NodeAndMut query = {nodeId, 0};
-            auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query);
+            auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query, NodeAndMutLt());
             while (mutIdIt != m_mutIdsByNodeId.end() && mutIdIt->first == nodeId) {
-                result.push_back(std::move(nodeAndMutToType<T>(*mutIdIt)));
+                if (mutIdIt->second != INVALID_MUTATION_ID) {
+                    result.push_back(std::move(nodeAndMutToType<T>(*mutIdIt)));
+                }
                 mutIdIt++;
             }
         } else {
             const NodeMutMiss query = {nodeId, 0, 0};
-            auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query);
+            auto mutIdIt = std::lower_bound(
+                m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
             while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
-                result.push_back(nodeAndMutAndMissToType<T>(*mutIdIt));
+                if (std::get<1>(*mutIdIt) != INVALID_MUTATION_ID) {
+                    result.push_back(nodeAndMutAndMissToType<T>(*mutIdIt));
+                }
                 mutIdIt++;
             }
         }
         return std::move(result);
     }
 
+    /**
+     * Does the node have at least one Mutation associated with it?
+     *
+     * @param[in] nodeId The node to lookup.
+     * @return true if the node has one or more Mutation.
+     */
     bool nodeHasMutations(const NodeID nodeId) {
         if (!m_mutIdsByNodeIdSorted) {
             sortMutIdsByNodeID();
         }
         if (!m_mutIdsByNodeId.empty()) {
             const std::pair<NodeID, MutationId> query = {nodeId, 0};
-            const auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query);
-            return mutIdIt != m_mutIdsByNodeId.end() && (mutIdIt->first == nodeId);
+            auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query, NodeAndMutLt());
+            while (mutIdIt != m_mutIdsByNodeId.end() && mutIdIt->first == nodeId) {
+                if (mutIdIt->second != INVALID_MUTATION_ID) {
+                    return true;
+                }
+                mutIdIt++;
+            }
+            return false;
         }
         const std::tuple<NodeID, MutationId, NodeID> query = {nodeId, 0, 0};
-        const auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query);
-        return mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId;
+        auto mutIdIt =
+            std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
+        while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
+            if (std::get<1>(*mutIdIt) != INVALID_MUTATION_ID) {
+                return true;
+            }
+            mutIdIt++;
+        }
+        return false;
     }
 
     /**
@@ -448,11 +474,15 @@ public:
         std::vector<T> result;
         if (!m_mutIdsByNodeId.empty()) {
             for (const auto& nodeAndMutId : m_mutIdsByNodeId) {
-                result.emplace_back(std::move(nodeAndMutToRevType<T>(nodeAndMutId)));
+                if (nodeAndMutId.second != INVALID_MUTATION_ID) {
+                    result.emplace_back(std::move(nodeAndMutToRevType<T>(nodeAndMutId)));
+                }
             }
         } else {
             for (const auto& triple : m_mutIdsByNodeIdAndMiss) {
-                result.emplace_back(nodeAndMutAndMissToRevType<T>(triple));
+                if (std::get<1>(triple) != INVALID_MUTATION_ID) {
+                    result.emplace_back(nodeAndMutAndMissToRevType<T>(triple));
+                }
             }
         }
         sortByMutation(result);
@@ -743,6 +773,30 @@ public:
     virtual bool samplesAreOrdered() const { return true; }
 
 protected:
+    struct NodeAndMutLt {
+        bool operator()(const GRG::NodeAndMut& lhs, const GRG::NodeAndMut& rhs) const {
+            if (lhs.first == INVALID_NODE_ID && rhs.first != INVALID_NODE_ID) {
+                return true;
+            }
+            if (lhs.first != INVALID_NODE_ID && rhs.first == INVALID_NODE_ID) {
+                return false;
+            }
+            return lhs < rhs;
+        }
+    };
+
+    struct NodeMutMissLt {
+        bool operator()(const GRG::NodeMutMiss& lhs, const GRG::NodeMutMiss& rhs) const {
+            if (std::get<0>(lhs) == INVALID_NODE_ID && std::get<0>(rhs) != INVALID_NODE_ID) {
+                return true;
+            }
+            if (std::get<0>(lhs) != INVALID_NODE_ID && std::get<0>(rhs) == INVALID_NODE_ID) {
+                return false;
+            }
+            return lhs < rhs;
+        }
+    };
+
     void visitTopoNodeOrderedDense(GRGVisitor& visitor, TraversalDirection direction, const NodeIDList& seedList);
     void visitTopoNodeOrderedSparse(GRGVisitor& visitor, TraversalDirection direction, const NodeIDList& seedList);
     void populateMutMissInfo();
@@ -750,15 +804,7 @@ protected:
     // m_mutIdsByNodeId gets appended to and then sorted periodically or as needed, using this
     // function. We rarely need to lookup Mutations by NodeID while modifying a GRG, so this ends
     // up being about 3x smaller than the previous multimap<> and many times faster.
-    void sortMutIdsByNodeID() {
-        if (!m_mutIdsByNodeId.empty()) {
-            release_assert(m_mutIdsByNodeIdAndMiss.empty());
-            std::sort(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end());
-        } else {
-            std::sort(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end());
-        }
-        m_mutIdsByNodeIdSorted = true;
-    }
+    void sortMutIdsByNodeID();
 
     // Templated helpers for transparently handling the cases where we do or don't have
     // missing data nodes.

--- a/src/grg.cpp
+++ b/src/grg.cpp
@@ -45,42 +45,40 @@ void GRG::removeMutation(const MutationId mutId, const NodeID nodeId) {
     m_mutations.ref(mutId) = Mutation();
 
     // Remove the node mapping.
-    if (nodeId != INVALID_NODE_ID) {
-        bool deleted = false;
-        if (!m_mutIdsByNodeId.empty()) {
-            const NodeAndMut query = {nodeId, 0};
-            auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query);
-            while (mutIdIt != m_mutIdsByNodeId.end() && mutIdIt->first == nodeId) {
-                if (mutIdIt->second == mutId) {
-                    m_mutIdsByNodeId.erase(mutIdIt);
-                    deleted = true;
-                    break;
-                }
-                mutIdIt++;
+    bool deleted = false;
+    if (!m_mutIdsByNodeId.empty()) {
+        const NodeAndMut query = {nodeId, 0};
+        auto mutIdIt = std::lower_bound(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), query, NodeAndMutLt());
+        while (mutIdIt != m_mutIdsByNodeId.end() && mutIdIt->first == nodeId) {
+            if (mutIdIt->second == mutId) {
+                mutIdIt->second = INVALID_MUTATION_ID;
+                deleted = true;
+                break;
             }
-        } else {
-            const NodeMutMiss query = {nodeId, 0, 0};
-            auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query);
-            while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
-                if (std::get<1>(*mutIdIt) == mutId) {
-                    m_mutIdsByNodeIdAndMiss.erase(mutIdIt);
-                    deleted = true;
-                    break;
-                }
-                mutIdIt++;
-            }
+            mutIdIt++;
         }
-        api_exc_check(deleted, "Could not find NodeId " << nodeId << " in mutation mapping");
+    } else {
+        const NodeMutMiss query = {nodeId, 0, 0};
+        auto mutIdIt =
+            std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
+        while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
+            if (std::get<1>(*mutIdIt) == mutId) {
+                std::get<1>(*mutIdIt) = INVALID_MUTATION_ID;
+                deleted = true;
+                break;
+            }
+            mutIdIt++;
+        }
     }
+    api_exc_check(deleted, "Could not find NodeId " << nodeId << " in mutation mapping");
     m_mutsAreOrdered = false;
 }
 
 MutationId GRG::addMutation(const Mutation& mutation, const NodeID nodeId, const NodeID missNodeId) {
     const MutationId mutId = m_mutations.size();
     m_mutations.push_back(mutation);
-    if (nodeId != INVALID_NODE_ID) {
-        release_assert(nodeId < this->numNodes());
-    }
+    release_assert(nodeId == INVALID_NODE_ID || nodeId < this->numNodes());
+    bool isSorted = this->m_mutIdsByNodeIdSorted;
     if (m_mutIdsByNodeIdAndMiss.empty() && missNodeId != INVALID_NODE_ID) {
         for (const auto& pair : m_mutIdsByNodeId) {
             m_mutIdsByNodeIdAndMiss.emplace_back(pair.first, pair.second, INVALID_NODE_ID);
@@ -89,11 +87,17 @@ MutationId GRG::addMutation(const Mutation& mutation, const NodeID nodeId, const
         m_mutIdsByNodeId.shrink_to_fit();
     }
     if (!m_mutIdsByNodeIdAndMiss.empty() || missNodeId != INVALID_NODE_ID) {
+        // It may stay sorted if the user is only adding Mutations to newly added nodes.
+        isSorted &= (m_mutIdsByNodeIdAndMiss.empty() ||
+                     (nodeId >= std::get<0>(m_mutIdsByNodeIdAndMiss.back()) && nodeId != INVALID_NODE_ID));
         m_mutIdsByNodeIdAndMiss.emplace_back(nodeId, mutId, missNodeId);
     } else {
+        // It may stay sorted if the user is only adding Mutations to newly added nodes.
+        isSorted &=
+            (m_mutIdsByNodeId.empty() || (nodeId >= m_mutIdsByNodeId.back().first && nodeId != INVALID_NODE_ID));
         this->m_mutIdsByNodeId.emplace_back(nodeId, mutId);
     }
-    this->m_mutIdsByNodeIdSorted = false;
+    this->m_mutIdsByNodeIdSorted = isSorted;
     if (m_mutsAreOrdered) {
         m_mutsAreOrdered = false;
     }
@@ -111,10 +115,12 @@ void GRG::sortMutations() {
             const MutationId newMutId = newMutations.size();
             const MutationId oldMutId = std::get<0>(triple);
             newMutations.push_back(std::move(m_mutations.atRef(oldMutId)));
+            const NodeID& mutNode = std::get<1>(triple);
+            const NodeID& missNode = std::get<2>(triple);
             if (hasMissing) {
-                mutIdsByNodeIdAndMiss.emplace_back(std::get<1>(triple), newMutId, std::get<2>(triple));
+                mutIdsByNodeIdAndMiss.emplace_back(mutNode, newMutId, missNode);
             } else {
-                mutIdsByNodeId.emplace_back(std::get<1>(triple), newMutId);
+                mutIdsByNodeId.emplace_back(mutNode, newMutId);
             }
         }
         m_mutations = std::move(newMutations);
@@ -199,6 +205,44 @@ template <> GRG::MutAndNode GRG::nodeAndMutAndMissToRevType(const GRG::NodeMutMi
 
 template <> GRG::MutNodeMiss GRG::nodeAndMutAndMissToRevType(const GRG::NodeMutMiss& triple) {
     return {std::get<1>(triple), std::get<0>(triple), std::get<2>(triple)};
+}
+
+void GRG::sortMutIdsByNodeID() {
+    if (!m_mutIdsByNodeId.empty()) {
+        release_assert(m_mutIdsByNodeIdAndMiss.empty());
+
+        // FIXME: the m_mutIdsByNodeId and m_mutIdsByNodeIdAndMiss need a better abstraction around
+        // them to avoid this yucky code. First we should convert from std::pair to std::tuple
+        // Compact out the soft-deleted Mutations
+        size_t j = 0;
+        for (size_t i = 0; i < m_mutIdsByNodeId.size(); i++) {
+            if (j != i) {
+                m_mutIdsByNodeId[j] = m_mutIdsByNodeId[i];
+            }
+            if (m_mutIdsByNodeId[i].second != INVALID_MUTATION_ID) {
+                j++;
+            }
+        }
+        m_mutIdsByNodeId.resize(j);
+
+        std::sort(m_mutIdsByNodeId.begin(), m_mutIdsByNodeId.end(), NodeAndMutLt());
+    } else {
+
+        // Compact out the soft-deleted Mutations
+        size_t j = 0;
+        for (size_t i = 0; i < m_mutIdsByNodeIdAndMiss.size(); i++) {
+            if (j != i) {
+                m_mutIdsByNodeIdAndMiss[j] = m_mutIdsByNodeIdAndMiss[i];
+            }
+            if (std::get<1>(m_mutIdsByNodeIdAndMiss[i]) != INVALID_MUTATION_ID) {
+                j++;
+            }
+        }
+        m_mutIdsByNodeIdAndMiss.resize(j);
+
+        std::sort(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), NodeMutMissLt());
+    }
+    m_mutIdsByNodeIdSorted = true;
 }
 
 void GRG::visitBfs(GRGVisitor& visitor,

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -49,7 +49,6 @@ namespace py = pybind11;
  */
 double SNPHWE(int64_t obs_hets, int64_t obs_hom1, int64_t obs_hom2);
 
-
 std::string mutStr(const grgl::Mutation& mut) {
     std::stringstream result;
     result << "<[pygrgl.Mutation] position=" << mut.getPosition() << ", ref_allele=" << mut.getRefAllele()
@@ -480,7 +479,9 @@ PYBIND11_MODULE(_grgl, m) {
                 :return: The list of NodeIDs that are root nodes.
                 :rtype: List[int]
             )^")
-        .def("get_node_mutation_pairs", &grgl::GRG::getNodesAndMutations<grgl::GRG::NodeAndMut>, R"^(
+        .def("get_node_mutation_pairs",
+             &grgl::GRG::getNodesAndMutations<grgl::GRG::NodeAndMut>,
+             R"^(
                 Get a list of pairs (NodeID, MutationID). Each Mutation typically
                 is associated to a single Node, but rarely it can have more than one
                 Node, in which case it will show up in more than one pair.
@@ -516,7 +517,10 @@ PYBIND11_MODULE(_grgl, m) {
                 :return: A list of tuples of (MutationID, NodeID, "missingness" NodeID).
                 :rtype: List[Tuple[int, int, int]]
             )^")
-        .def("get_mutations_for_node", &grgl::GRG::getMutationsForNode<grgl::MutationId>, py::arg("node_id"), R"^(
+        .def("get_mutations_for_node",
+             &grgl::GRG::getMutationsForNode<grgl::MutationId>,
+             py::arg("node_id"),
+             R"^(
                 Get all the (zero or more) Mutations associated with the given NodeID.
 
                 :param node_id: The NodeID to get mutations for.
@@ -1132,6 +1136,7 @@ PYBIND11_MODULE(_grgl, m) {
     )^");
 
     m.attr("INVALID_NODE") = grgl::INVALID_NODE_ID;
+    m.attr("INVALID_MUTATION") = grgl::INVALID_MUTATION_ID;
     m.attr("COAL_COUNT_NOT_SET") = grgl::COAL_COUNT_NOT_SET;
     m.attr("NO_UP_EDGES") = grgl::NO_UP_EDGES;
     m.attr("POPULATION_UNSPECIFIED") = grgl::POPULATION_UNSPECIFIED;


### PR DESCRIPTION
Previously there were two performance problems with modifying GRG:
1. The Mutations were hard deleted from a std::vector, which resulted in an O(N) copy of data every remove_mutation()
2. The adding of a new Mutation flagged the mutation-to-node mapping to be resorted again on the next read access. This is overly aggressive IF AND ONLY IF you are adding Mutations to newly added nodes, then it is trivial to keep the mapping in the right sorted order by just appending to it.