### PR TITLE
Fixed bug where DOWN matmul wouldn't recognize nodes added to the grg

### DIFF
--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -1006,22 +1006,78 @@ public:
     NodeIDList getOrderedNodes(TraversalDirection direction) override {
         // TODO: replace this error with actually using a Visitor here to get the numbering.
         api_exc_check(nodesAreTopo(), "Nodes are not in topological order; use a Visitor instead");
-        NodeIDList result(numNodes());
+        // The "negative" nodes are interleaved with regular positive nodes in
+        // m_nodes (any call sequence of make_node(negative=true) followed by
+        // make_node() yields interleaved IDs -- e.g. an algorithm that adds an
+        // offspring sample then a bubble per recombine_multi call produces
+        // m_negativeNodes = [N, N+2, N+4, ...] with bubbles at the odd
+        // positions). The previous implementation here:
+        //   (a) placed negative IDs at result[0..numNegative-1], then
+        //   (b) wrote std::iota over result[0..numNodes-numNegative-1] with
+        //       values 0..numNodes-numNegative-1, OVERWRITING the negative IDs
+        //       just placed and silently filling result[numNodes-numNegative..]
+        //       with default-constructed 0s, and
+        //   (c) assumed positive IDs were contiguous in 0..numNodes-numNegative-1,
+        //       which is false whenever a single negative-then-positive pair has
+        //       ever been added -- the high positive IDs (e.g. bubble nodes
+        //       created post-load) are simply omitted from the result list.
+        // Consequences observed downstream: matmul DOWN never visited offspring
+        // (their nodeValues stayed at 0 -> samples carried no mutations); fast
+        // serialization paths walking this list never visited bubble nodes, so
+        // save_grg dropped them silently.
+        //
+        // This rewrite uses an explicit set lookup on the negative IDs so the
+        // positive iteration walks the true positive ID set (which may be
+        // sparse). Negatives are placed at the correct end for the requested
+        // direction: at the end for DIRECTION_DOWN (top-down: ancestors first,
+        // leaves last), and at the beginning for DIRECTION_UP (bottom-up:
+        // leaves first, ancestors last).
+        // Within the negative-node section, ordering matters across
+        // generations. Recombination algorithms (e.g. NonDuplicationRecombination)
+        // can attach a new offspring directly to an older offspring via the
+        // path-compression early-attach branch, producing
+        //   older_negative -> newer_negative
+        // DOWN edges in multi-generation simulations. Older offspring
+        // therefore become non-leaf parents of newer offspring.
+        //
+        // Creation order in m_negativeNodes (older first) matches the
+        // older->younger parent->child orientation: for DIRECTION_DOWN
+        // (parents before children), forward iteration is correct; for
+        // DIRECTION_UP (children before parents), iterate in reverse.
+        NodeIDList result;
+        result.reserve(numNodes());
         const size_t numNegative = m_negativeNodes.size();
-        // First, add the negative nodes in reverse order
-        size_t i = 0;
-        for (size_t j = numNegative; j > 0; j--) {
-            result[i++] = m_negativeNodes[j - 1];
-        }
+        NodeIDSet negSet(m_negativeNodes.begin(), m_negativeNodes.end());
         if (direction == grgl::TraversalDirection::DIRECTION_DOWN) {
-            auto it = result.rbegin();
-            std::advance(it, numNegative);
-            std::iota(it, result.rend(), 0);
+            // Positives in DESCENDING ID order (roots first), skipping negatives.
+            for (NodeID id = numNodes(); id > 0; id--) {
+                const NodeID actualId = id - 1;
+                if (negSet.find(actualId) == negSet.end()) {
+                    result.push_back(actualId);
+                }
+            }
+            // Negatives in creation order (older first): parents of any
+            // intra-negative chain visited before their children.
+            for (NodeID nid : m_negativeNodes) {
+                result.push_back(nid);
+            }
         } else {
-            auto it = result.begin();
-            std::advance(it, numNegative);
-            std::iota(it, result.end(), 0);
+            // Negatives in REVERSE creation order (younger first): children
+            // of any intra-negative chain visited before their parents, so
+            // matmulSumChildrenUp on an older negative finds its younger
+            // negative children already finalized.
+            for (auto it = m_negativeNodes.rbegin(); it != m_negativeNodes.rend(); ++it) {
+                result.push_back(*it);
+            }
+            // Positives in ASCENDING ID order (samples first, roots last),
+            // skipping negatives.
+            for (NodeID id = 0; id < numNodes(); id++) {
+                if (negSet.find(id) == negSet.end()) {
+                    result.push_back(id);
+                }
+            }
         }
+        release_assert(result.size() == numNodes());
         return std::move(result);
     }
 


### PR DESCRIPTION
When testing downwards matmul with grg recombination, negative nodes weren't recognized. getOrderedNodes() would return a malformed list when negative nodes were present, leading to:

- matmul with DOWN traversal to return 0 for offspring sample columns even when those offspring carried mutations, because the sample nodes were never visited and their accumulated values stayed at 0.
- save_grg to silently drop post-load mutation-bearing nodes. After save+reload, those mutations were no longer attached to any node in the reloaded graph.

There were three compounding bugs in the function body:

1. The function first placed the negative-node IDs in the result list, then ran a fill operation that overwrote those same slots with positive IDs. The negative nodes ended up missing from the result entirely.
2. For DOWN traversal it placed negative nodes at the front of the result, but DOWN traversal needs leaves (samples) at the end — parents have to be visited before children so parent values can propagate down.
3. The fill operation assumed positive node IDs occupied a contiguous range 0..numPositive-1. That's only true if negatives were created last. Any algorithm that interleaves negative and positive make_node calls (e.g., creating one new sample plus one or more intermediate "bubble" nodes per call) produces non-contiguous positive IDs, and the high positive IDs simply never appeared in the result.

The bugs were fixed with two structural changes:

1. Replace the contiguous-range fill with an explicit skip-set lookup over m_negativeNodes. The positive-ID iteration walks every ID in [0, numNodes()) and adds those not in the skip set, so it correctly handles interleaved positives and negatives.
2. Place negatives at the right end for the requested direction: at the END for DOWN traversal (leaves visited last), at the BEGINNING for UP traversal (leaves visited first). Within the negative section, iterate in creation order for DOWN and reverse creation order for UP. This handles the multi-generation case where algorithms create chains of older_negative → newer_negative DOWN edges and UP traversal needs the chain visited child-first.

A release_assert at the end checks that the result has exactly numNodes() entries, catching any future drift from this invariant.