### PR TITLE
Fix negnode matmul

### DIFF
--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -451,7 +451,8 @@ public:
             }
         } else {
             const NodeMutMiss query = {nodeId, 0, 0};
-            auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
+            auto mutIdIt = std::lower_bound(
+                m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
             while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
                 if (std::get<1>(*mutIdIt) != INVALID_MUTATION_ID) {
                     result.push_back(nodeAndMutAndMissToType<T>(*mutIdIt));
@@ -487,7 +488,8 @@ public:
             return false;
         }
         const std::tuple<NodeID, MutationId, NodeID> query = {nodeId, 0, 0};
-        auto mutIdIt = std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
+        auto mutIdIt =
+            std::lower_bound(m_mutIdsByNodeIdAndMiss.begin(), m_mutIdsByNodeIdAndMiss.end(), query, NodeMutMissLt());
         while (mutIdIt != m_mutIdsByNodeIdAndMiss.end() && std::get<0>(*mutIdIt) == nodeId) {
             if (std::get<1>(*mutIdIt) != INVALID_MUTATION_ID) {
                 return true;
@@ -1003,83 +1005,7 @@ public:
 
     bool edgesAreOrdered() const override { return false; }
 
-    NodeIDList getOrderedNodes(TraversalDirection direction) override {
-        // TODO: replace this error with actually using a Visitor here to get the numbering.
-        api_exc_check(nodesAreTopo(), "Nodes are not in topological order; use a Visitor instead");
-        // The "negative" nodes are interleaved with regular positive nodes in
-        // m_nodes (any call sequence of make_node(negative=true) followed by
-        // make_node() yields interleaved IDs -- e.g. an algorithm that adds an
-        // offspring sample then a bubble per recombine_multi call produces
-        // m_negativeNodes = [N, N+2, N+4, ...] with bubbles at the odd
-        // positions). The previous implementation here:
-        //   (a) placed negative IDs at result[0..numNegative-1], then
-        //   (b) wrote std::iota over result[0..numNodes-numNegative-1] with
-        //       values 0..numNodes-numNegative-1, OVERWRITING the negative IDs
-        //       just placed and silently filling result[numNodes-numNegative..]
-        //       with default-constructed 0s, and
-        //   (c) assumed positive IDs were contiguous in 0..numNodes-numNegative-1,
-        //       which is false whenever a single negative-then-positive pair has
-        //       ever been added -- the high positive IDs (e.g. bubble nodes
-        //       created post-load) are simply omitted from the result list.
-        // Consequences observed downstream: matmul DOWN never visited offspring
-        // (their nodeValues stayed at 0 -> samples carried no mutations); fast
-        // serialization paths walking this list never visited bubble nodes, so
-        // save_grg dropped them silently.
-        //
-        // This rewrite uses an explicit set lookup on the negative IDs so the
-        // positive iteration walks the true positive ID set (which may be
-        // sparse). Negatives are placed at the correct end for the requested
-        // direction: at the end for DIRECTION_DOWN (top-down: ancestors first,
-        // leaves last), and at the beginning for DIRECTION_UP (bottom-up:
-        // leaves first, ancestors last).
-        // Within the negative-node section, ordering matters across
-        // generations. Recombination algorithms (e.g. NonDuplicationRecombination)
-        // can attach a new offspring directly to an older offspring via the
-        // path-compression early-attach branch, producing
-        //   older_negative -> newer_negative
-        // DOWN edges in multi-generation simulations. Older offspring
-        // therefore become non-leaf parents of newer offspring.
-        //
-        // Creation order in m_negativeNodes (older first) matches the
-        // older->younger parent->child orientation: for DIRECTION_DOWN
-        // (parents before children), forward iteration is correct; for
-        // DIRECTION_UP (children before parents), iterate in reverse.
-        NodeIDList result;
-        result.reserve(numNodes());
-        const size_t numNegative = m_negativeNodes.size();
-        NodeIDSet negSet(m_negativeNodes.begin(), m_negativeNodes.end());
-        if (direction == grgl::TraversalDirection::DIRECTION_DOWN) {
-            // Positives in DESCENDING ID order (roots first), skipping negatives.
-            for (NodeID id = numNodes(); id > 0; id--) {
-                const NodeID actualId = id - 1;
-                if (negSet.find(actualId) == negSet.end()) {
-                    result.push_back(actualId);
-                }
-            }
-            // Negatives in creation order (older first): parents of any
-            // intra-negative chain visited before their children.
-            for (NodeID nid : m_negativeNodes) {
-                result.push_back(nid);
-            }
-        } else {
-            // Negatives in REVERSE creation order (younger first): children
-            // of any intra-negative chain visited before their parents, so
-            // matmulSumChildrenUp on an older negative finds its younger
-            // negative children already finalized.
-            for (auto it = m_negativeNodes.rbegin(); it != m_negativeNodes.rend(); ++it) {
-                result.push_back(*it);
-            }
-            // Positives in ASCENDING ID order (samples first, roots last),
-            // skipping negatives.
-            for (NodeID id = 0; id < numNodes(); id++) {
-                if (negSet.find(id) == negSet.end()) {
-                    result.push_back(id);
-                }
-            }
-        }
-        release_assert(result.size() == numNodes());
-        return std::move(result);
-    }
+    NodeIDList getOrderedNodes(TraversalDirection direction) override;
 
     /**
      * Create a new node in the GRG.

--- a/include/grgl/grg.h
+++ b/include/grgl/grg.h
@@ -1006,22 +1006,78 @@ public:
     NodeIDList getOrderedNodes(TraversalDirection direction) override {
         // TODO: replace this error with actually using a Visitor here to get the numbering.
         api_exc_check(nodesAreTopo(), "Nodes are not in topological order; use a Visitor instead");
-        NodeIDList result(numNodes());
+        // The "negative" nodes are interleaved with regular positive nodes in
+        // m_nodes (any call sequence of make_node(negative=true) followed by
+        // make_node() yields interleaved IDs -- e.g. an algorithm that adds an
+        // offspring sample then a bubble per recombine_multi call produces
+        // m_negativeNodes = [N, N+2, N+4, ...] with bubbles at the odd
+        // positions). The previous implementation here:
+        //   (a) placed negative IDs at result[0..numNegative-1], then
+        //   (b) wrote std::iota over result[0..numNodes-numNegative-1] with
+        //       values 0..numNodes-numNegative-1, OVERWRITING the negative IDs
+        //       just placed and silently filling result[numNodes-numNegative..]
+        //       with default-constructed 0s, and
+        //   (c) assumed positive IDs were contiguous in 0..numNodes-numNegative-1,
+        //       which is false whenever a single negative-then-positive pair has
+        //       ever been added -- the high positive IDs (e.g. bubble nodes
+        //       created post-load) are simply omitted from the result list.
+        // Consequences observed downstream: matmul DOWN never visited offspring
+        // (their nodeValues stayed at 0 -> samples carried no mutations); fast
+        // serialization paths walking this list never visited bubble nodes, so
+        // save_grg dropped them silently.
+        //
+        // This rewrite uses an explicit set lookup on the negative IDs so the
+        // positive iteration walks the true positive ID set (which may be
+        // sparse). Negatives are placed at the correct end for the requested
+        // direction: at the end for DIRECTION_DOWN (top-down: ancestors first,
+        // leaves last), and at the beginning for DIRECTION_UP (bottom-up:
+        // leaves first, ancestors last).
+        // Within the negative-node section, ordering matters across
+        // generations. Recombination algorithms (e.g. NonDuplicationRecombination)
+        // can attach a new offspring directly to an older offspring via the
+        // path-compression early-attach branch, producing
+        //   older_negative -> newer_negative
+        // DOWN edges in multi-generation simulations. Older offspring
+        // therefore become non-leaf parents of newer offspring.
+        //
+        // Creation order in m_negativeNodes (older first) matches the
+        // older->younger parent->child orientation: for DIRECTION_DOWN
+        // (parents before children), forward iteration is correct; for
+        // DIRECTION_UP (children before parents), iterate in reverse.
+        NodeIDList result;
+        result.reserve(numNodes());
         const size_t numNegative = m_negativeNodes.size();
-        // First, add the negative nodes in reverse order
-        size_t i = 0;
-        for (size_t j = numNegative; j > 0; j--) {
-            result[i++] = m_negativeNodes[j - 1];
-        }
+        NodeIDSet negSet(m_negativeNodes.begin(), m_negativeNodes.end());
         if (direction == grgl::TraversalDirection::DIRECTION_DOWN) {
-            auto it = result.rbegin();
-            std::advance(it, numNegative);
-            std::iota(it, result.rend(), 0);
+            // Positives in DESCENDING ID order (roots first), skipping negatives.
+            for (NodeID id = numNodes(); id > 0; id--) {
+                const NodeID actualId = id - 1;
+                if (negSet.find(actualId) == negSet.end()) {
+                    result.push_back(actualId);
+                }
+            }
+            // Negatives in creation order (older first): parents of any
+            // intra-negative chain visited before their children.
+            for (NodeID nid : m_negativeNodes) {
+                result.push_back(nid);
+            }
         } else {
-            auto it = result.begin();
-            std::advance(it, numNegative);
-            std::iota(it, result.end(), 0);
+            // Negatives in REVERSE creation order (younger first): children
+            // of any intra-negative chain visited before their parents, so
+            // matmulSumChildrenUp on an older negative finds its younger
+            // negative children already finalized.
+            for (auto it = m_negativeNodes.rbegin(); it != m_negativeNodes.rend(); ++it) {
+                result.push_back(*it);
+            }
+            // Positives in ASCENDING ID order (samples first, roots last),
+            // skipping negatives.
+            for (NodeID id = 0; id < numNodes(); id++) {
+                if (negSet.find(id) == negSet.end()) {
+                    result.push_back(id);
+                }
+            }
         }
+        release_assert(result.size() == numNodes());
         return std::move(result);
     }
 

--- a/src/grg.cpp
+++ b/src/grg.cpp
@@ -585,4 +585,33 @@ void MutableGRG::compact(NodeID nodeId) {
     }
 }
 
+NodeIDList MutableGRG::getOrderedNodes(TraversalDirection direction) {
+    // TODO: replace this error with actually using a Visitor here to get the numbering.
+    api_exc_check(nodesAreTopo(), "Nodes are not in topological order; use a Visitor instead");
+    // The "negative" nodes can be interleaved with regular positive nodes in m_nodes (any call
+    // sequence of make_node(negative=true) followed by make_node() yields interleaved IDs)
+    NodeIDList result;
+    result.reserve(numNodes());
+    const size_t numNegative = m_negativeNodes.size();
+    for (auto it = m_negativeNodes.crbegin(); it != m_negativeNodes.crend(); ++it) {
+        result.push_back(*it);
+    }
+    size_t nextNeg = 0;
+    // Positives in ASCENDING ID order (samples first, roots last), skipping negatives.
+    for (NodeID id = 0; id < numNodes(); id++) {
+        if (nextNeg < numNegative && m_negativeNodes[nextNeg] == id) {
+            nextNeg++;
+            continue;
+        }
+        result.push_back(id);
+    }
+    release_assert(nextNeg == numNegative); // We better have seen all of the negative nodes!
+    release_assert(result.size() == numNodes());
+    // The DOWN direction is just the reverse of the list that we created for UP
+    if (direction == grgl::TraversalDirection::DIRECTION_DOWN) {
+        vectReverse(result);
+    }
+    return std::move(result);
+}
+
 } // namespace grgl

--- a/src/util.h
+++ b/src/util.h
@@ -270,4 +270,14 @@ inline std::string getTmpDir() {
     return "/tmp";
 }
 
+template <typename T> inline void vectReverse(std::vector<T>& vect) {
+    if (vect.empty()) {
+        return;
+    }
+    size_t j = vect.size() - 1;
+    for (size_t i = 0; i < j; i++, j--) {
+        std::swap(vect[i], vect[j]);
+    }
+}
+
 #endif /* GRGL_UTIL_H */

--- a/test/endtoend/test_modify.py
+++ b/test/endtoend/test_modify.py
@@ -86,7 +86,9 @@ class TestGrgModify(unittest.TestCase):
         # Pick a different random node and add two mutations to it.
         self.assertTrue(grg.num_nodes > 1001)
         new_mut_id1 = grg.add_mutation(pygrgl.Mutation(0, "FAKE ALT", "00"), 500)
-        new_mut_id2 = grg.add_mutation(pygrgl.Mutation(500_000_000, "FAKE ALT2", "002"), 1001)
+        new_mut_id2 = grg.add_mutation(
+            pygrgl.Mutation(500_000_000, "FAKE ALT2", "002"), 1001
+        )
         self.assertNotEqual(new_mut_id1, new_mut_id2)
         self.assertFalse(grg.mutations_are_ordered)
         # The node->mut map should be updated properly as well
@@ -121,7 +123,7 @@ class TestGrgModify(unittest.TestCase):
         self.assertFalse(grg.samples_are_ordered)
 
         # Do matmul and get the value for sample 10 (which is "old" sample 60)
-        inmat = numpy.ones( (1, grg.num_mutations) )
+        inmat = numpy.ones((1, grg.num_mutations))
         result = pygrgl.matmul(grg, inmat, pygrgl.TraversalDirection.DOWN)[0]
         old_value = result[10]
 
@@ -152,7 +154,9 @@ class TestGrgModify(unittest.TestCase):
 
         negative_new = grg.make_node(negative=True)
         self.assertFalse(grg.nodes_are_ordered)
-        grg.connect(0, -negative_new)                # Connect negative as child: breaks counting order
+        grg.connect(
+            0, -negative_new
+        )  # Connect negative as child: breaks counting order
         self.assertFalse(grg.nodes_are_ordered)
 
         topo_list = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
@@ -162,10 +166,107 @@ class TestGrgModify(unittest.TestCase):
         # Now TRULY break the topological order, which will force the get_topo_order() to run a DFS
         # and produce a new order
         negative_new = grg.make_node(negative=True)
-        grg.connect(-negative_new, 10)                # Break the order entirely
+        grg.connect(-negative_new, 10)  # Break the order entirely
 
         # FIXME: this will barf right now
         topo_list = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
+
+    def test_regr_negnodes_matmul(self):
+        """
+        Regression test for the following scenario: load a MutableGRG, add some positive and
+        negative nodes, interleaved (alternating between them). Verify that the topological
+        order produces the correct order (negative nodes first), other newly added nodes last.
+        Verify that DOWN matmul() produces the expected result. Verify that matmul() after
+        set_samples() produces the expected result.
+        """
+        grg = pygrgl.load_mutable_grg(self.grg_filename, load_up_edges=True)
+
+        # Check our order invariant before any changes.
+        topo_up = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
+        topo_down = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.DOWN, [])
+        self.assertEqual(topo_up, list(reversed(topo_down)))
+
+        # Get our original matmul result
+        rand_input = numpy.random.standard_normal((1, grg.num_mutations))
+        orig_product = pygrgl.matmul(grg, rand_input, pygrgl.TraversalDirection.DOWN)[0]
+
+        # Just add two rows of new nodes above the previous roots and below the previous samples.
+        orig_node_ct = grg.num_nodes
+        orig_roots = grg.get_root_nodes()
+        orig_samples = grg.get_sample_nodes()
+
+        above1 = []
+        for r in orig_roots:
+            a = grg.make_node()
+            grg.connect(a, r)
+            above1.append(a)
+
+        below1 = []
+        for s in orig_samples:
+            b = grg.make_node(negative=True)
+            grg.connect(s, -b)
+            below1.append(b)
+
+        above2 = []
+        for r in above1:
+            a = grg.make_node()
+            grg.connect(a, r)
+            above2.append(a)
+
+        below2 = []
+        for s in below1:
+            b = grg.make_node(negative=True)
+            grg.connect(s, -b)
+            below2.append(b)
+
+        self.assertFalse(grg.nodes_are_ordered)
+
+        new_below = len(orig_samples) * 2
+        new_above = len(orig_roots) * 2
+
+        # Compare to our original matmul result. We have not modified the Mutations or Samples,
+        # so this should be identical!
+        product2 = pygrgl.matmul(grg, rand_input, pygrgl.TraversalDirection.DOWN)[0]
+        numpy.testing.assert_allclose(orig_product, product2)
+
+        topo_up = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
+        # Correct counts.
+        self.assertEqual(len(topo_up), grg.num_nodes)
+        self.assertEqual(len(topo_up), orig_node_ct + new_above + new_below)
+        # Every node appears only once.
+        self.assertEqual(len(topo_up), len(set(topo_up)))
+        # The new "above" nodes should be at the beginning
+        self.assertEqual(
+            topo_up[:new_above], list(reversed(above2)) + list(reversed(above1))
+        )
+        # The new "below" nodes should be at the end
+        self.assertEqual(
+            topo_up[-new_below:], list(reversed(below2)) + list(reversed(below1))
+        )
+
+        topo_down = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.DOWN, [])
+        # Correct counts.
+        self.assertEqual(len(topo_down), grg.num_nodes)
+        self.assertEqual(len(topo_down), orig_node_ct + new_above + new_below)
+        # Every node appears only once.
+        self.assertEqual(len(topo_down), len(set(topo_down)))
+        # The new "below" nodes should be at the beginning
+        self.assertEqual(
+            topo_up[:new_below], list(reversed(below2)) + list(reversed(below1))
+        )
+        # The new "below" nodes should be at the end
+        self.assertEqual(
+            topo_up[-new_above:], list(reversed(above2)) + list(reversed(above1))
+        )
+
+        # The two directions should be equivalent, just opposite orders.
+        self.assertEqual(topo_up, list(reversed(topo_down)))
+
+        # Save our new samples, and verify that this still doesn't change the matmul result.
+        grg.set_samples(below2)
+        self.assertEqual(grg.get_samples(), below2)
+        product3 = pygrgl.matmul(grg, rand_input, pygrgl.TraversalDirection.DOWN)[0]
+        numpy.testing.assert_allclose(orig_product, product3)
 
 
 if __name__ == "__main__":

--- a/test/endtoend/test_modify.py
+++ b/test/endtoend/test_modify.py
@@ -230,19 +230,18 @@ class TestGrgModify(unittest.TestCase):
         numpy.testing.assert_allclose(orig_product, product2)
 
         topo_up = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.UP, [])
+
         # Correct counts.
         self.assertEqual(len(topo_up), grg.num_nodes)
         self.assertEqual(len(topo_up), orig_node_ct + new_above + new_below)
         # Every node appears only once.
         self.assertEqual(len(topo_up), len(set(topo_up)))
-        # The new "above" nodes should be at the beginning
+        # The new "below" nodes should be at the beginning
         self.assertEqual(
-            topo_up[:new_above], list(reversed(above2)) + list(reversed(above1))
+            topo_up[:new_below], list(reversed(below2)) + list(reversed(below1))
         )
-        # The new "below" nodes should be at the end
-        self.assertEqual(
-            topo_up[-new_below:], list(reversed(below2)) + list(reversed(below1))
-        )
+        # The new "above" nodes should be at the end
+        self.assertEqual(topo_up[-new_above:], above1 + above2)
 
         topo_down = pygrgl.get_topo_order(grg, pygrgl.TraversalDirection.DOWN, [])
         # Correct counts.
@@ -250,21 +249,19 @@ class TestGrgModify(unittest.TestCase):
         self.assertEqual(len(topo_down), orig_node_ct + new_above + new_below)
         # Every node appears only once.
         self.assertEqual(len(topo_down), len(set(topo_down)))
-        # The new "below" nodes should be at the beginning
+        # The new "above" nodes should be at the beginning
         self.assertEqual(
-            topo_up[:new_below], list(reversed(below2)) + list(reversed(below1))
+            topo_down[:new_above], list(reversed(above2)) + list(reversed(above1))
         )
         # The new "below" nodes should be at the end
-        self.assertEqual(
-            topo_up[-new_above:], list(reversed(above2)) + list(reversed(above1))
-        )
+        self.assertEqual(topo_down[-new_below:], below1 + below2)
 
         # The two directions should be equivalent, just opposite orders.
         self.assertEqual(topo_up, list(reversed(topo_down)))
 
         # Save our new samples, and verify that this still doesn't change the matmul result.
         grg.set_samples(below2)
-        self.assertEqual(grg.get_samples(), below2)
+        self.assertEqual(grg.get_sample_nodes(), below2)
         product3 = pygrgl.matmul(grg, rand_input, pygrgl.TraversalDirection.DOWN)[0]
         numpy.testing.assert_allclose(orig_product, product3)
 

--- a/test/unit/test_util.cpp
+++ b/test/unit/test_util.cpp
@@ -67,3 +67,38 @@ TEST(HapHelpers, bitwiseSubtract) {
     std::vector<size_t> expected = {4, 11, 77, 81};
     ASSERT_EQ(bitsSet, expected);
 }
+
+TEST(Util, vectReverse) {
+    grgl::NodeIDList theVect;
+
+    // Edge case: empty
+    vectReverse(theVect);
+    ASSERT_TRUE(theVect.empty());
+
+    // Edge case: 1 element
+    theVect = {91919191};
+    vectReverse(theVect);
+    ASSERT_EQ(theVect[0], 91919191);
+
+    // Edge case: 2 elements
+    theVect = {1001, 999};
+    vectReverse(theVect);
+    ASSERT_EQ(theVect[0], 999);
+    ASSERT_EQ(theVect[1], 1001);
+
+    // Odd # of elements
+    theVect = {1, 9, 2};
+    vectReverse(theVect);
+    ASSERT_EQ(theVect[0], 2);
+    ASSERT_EQ(theVect[1], 9);
+    ASSERT_EQ(theVect[2], 1);
+
+    // Even # of elements
+    theVect = {100, 66, 87, 33};
+    vectReverse(theVect);
+    ASSERT_EQ(theVect[0], 33);
+    ASSERT_EQ(theVect[1], 87);
+    ASSERT_EQ(theVect[2], 66);
+    ASSERT_EQ(theVect[3], 100);
+
+}


### PR DESCRIPTION
Just a slightly revised version of @AA-maker's [fix for matmul() with negative nodes](https://github.com/aprilweilab/grgl/pull/139).

1. Add an automated regression test for the scenario. I verified that it passed on Akshay's original fix, and my modified version.
2. Simplify `getOrderedNodes()`: only generate the UP order, and then use the new `vectReverse()` to get the DOWN order if needed.
  * GRG's codebase is C++11 compatible, so we don't use `std::reverse` (C++17 only)
  * Use the `.crbegin()` and `.crend()` _constant_ iterators, since we don't need to modify the vector
3. Use the ordered nature of the negative node list and the node ID range to remove the need for checking a set for negative nodes