### PR TITLE
Sample filtering now allows re-ordering of samples

### DIFF
--- a/include/grgl/serialize.h
+++ b/include/grgl/serialize.h
@@ -72,7 +72,7 @@ public:
     explicit RenumberAndWriteVisitor(std::ostream& outStream, NodeIDSizeT numNodes, bool allowSimplify);
     bool getChildren(const grgl::GRGPtr& grg, const grgl::NodeID nodeId, NodeIDList& result, NodeIDSizeT& parentCoals);
     bool shouldKeep(const grgl::GRGPtr& grg, const grgl::NodeID nodeId) const;
-    NodeIDSizeT setKeepSamples(const grgl::GRGPtr& grg, grgl::NodeIDList sampleIdList, bool warn);
+    NodeIDSizeT setKeepSamples(const grgl::GRGPtr& grg, const grgl::NodeIDList& sampleIdList, bool warn);
     NodeIDList setKeepMutations(const grgl::GRGPtr& grg, const grgl::NodeIDList& mutationIDList);
     bool keepMutation(const MutationId mutId);
     bool visit(const grgl::GRGPtr& grg,
@@ -144,6 +144,21 @@ GRGPtr loadImmutableGRG(const std::string& filename, bool loadUpEdges = false);
 
 std::pair<NodeIDSizeT, EdgeSizeT> saveGRG(const GRGPtr& theGRG, const std::string& filename, bool allowSimplify = true);
 
+/**
+ * Save a subset of the GRG, either by Mutations (downward traversal) or Samples (upward traversal).
+ *
+ * @param[in] theGRG The GRG object to save.
+ * @param[in] filename The output filename to use.
+ * @param[in] direction Subset by mutations (TraversalDirection::DIRECTION_DOWN) or samples
+ * (TraversalDirection::DIRECTION_UP)
+ * @param[in] seedList The list of MutationIDs or SampleIDs (NodeIDs of samples) to keep. For samples, the order of this
+ * list matters - it defines the order of the samples in the new GRG. For example, [0, 1, 2, 3] keeps the first four
+ * samples in their original order, but [3, 2, 1, 0] keeps the same samples but reverses their order in the new GRG.
+ * This means that the SampleIDs will change as 0->3, 1->2, 2->1, 3->0. The IndividualIDs mapped to individuals will be
+ * properly maintained if present.
+ * @param[in] byRange Just metadata about the range of base-pairs that this subset will cover. It does not have any
+ * effect on the actual filtering option, IT ONLY CHANGES METADATA.
+ */
 bool saveGRGSubset(const GRGPtr& theGRG,
                    const std::string& filename,
                    const TraversalDirection direction,

--- a/src/python/_grgl.cpp
+++ b/src/python/_grgl.cpp
@@ -982,7 +982,11 @@ PYBIND11_MODULE(_grgl, m) {
         :param direction: Downward means the seeds should be a list of MutationID that should be kept in
             the graph. Upward means the seeds should be a list of sample NodeID that should be kept.
         :type direction: pygrgl.TraversalDirection
-        :param seed_list: A list of MutationID or NodeID (see direction parameter).
+        :param seed_list: The list of MutationIDs or SampleIDs (NodeIDs of samples) to keep. For samples, the order of this list
+            matters - it defines the order of the samples in the new GRG. For example, [0, 1, 2, 3] keeps the first four samples in
+            their original order, but [3, 2, 1, 0] keeps the same samples but reverses their order in the new GRG. This means that
+            the SampleIDs will change as 0->3, 1->2, 2->1, 3->0. The IndividualIDs mapped to individuals will be properly maintained
+            if present.
         :type seed_list: List[int]
         :param bp_range: A pair of integers specifying the base-pair range that this GRG covers. This is just
             meta-data, and does not change the filtering behavior.

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -240,44 +240,48 @@ std::vector<NodeIDSizeT> calculateCoalsForSamples(const GRGPtr& grg, const NodeI
 }
 
 // Set which samples we want to keep; if never called then we keep all samples.
-NodeIDSizeT RenumberAndWriteVisitor::setKeepSamples(const grgl::GRGPtr& grg, grgl::NodeIDList sampleIDList, bool warn) {
+// The ORDER OF THE SAMPLES in sampleIDList matters, as this will be the new order of those samples in
+// the resulting GRG.
+NodeIDSizeT
+RenumberAndWriteVisitor::setKeepSamples(const grgl::GRGPtr& grg, const grgl::NodeIDList& sampleIDList, bool warn) {
+    release_assert(grg->samplesAreOrdered());
+
     NodeIDSizeT numSamples = 0;
-    NodeID prevSampleId = INVALID_NODE_ID;
-    std::sort(sampleIDList.begin(), sampleIDList.end());
-    m_nodeIdMap.resize(sampleIDList.back() + 1, INVALID_NODE_ID);
+    const NodeID maxKept = vectMax(sampleIDList);
+    m_nodeIdMap.resize(maxKept + 1, INVALID_NODE_ID);
     release_assert(m_revIdMap.empty());
     const size_t ploidy = grg->getPloidy();
     NodeIDList fullIndividuals;
+    std::vector<bool> seen(grg->numSamples(), false);
     for (const auto sampleId : sampleIDList) {
         if (!grg->isSample(sampleId)) {
             throw ApiMisuseFailure("Not a valid sampleId");
         }
-        if (sampleId != prevSampleId) {
-            const NodeID newSampleId = numSamples++;
-            m_nodeIdMap.at(sampleId) = newSampleId;
-            m_revIdMap.push_back(sampleId);
-            release_assert(m_revIdMap.size() == newSampleId + 1);
+        api_exc_check(!seen.at(sampleId), "Duplicate sample in seed list; not allowed.");
+        seen[sampleId] = true;
+        const NodeID newSampleId = numSamples++;
+        m_nodeIdMap.at(sampleId) = newSampleId;
+        m_revIdMap.push_back(sampleId);
+        release_assert(m_revIdMap.size() == newSampleId + 1);
 
-            // Now check to see if we have this full individual. That means that nodeIdMap
-            // should have all PLOIDY consecutive haplotypes.
-            if ((sampleId % ploidy) == (ploidy - 1)) {
-                bool fullIndividual = true;
-                const NodeID individualId = sampleId / ploidy;
-                const NodeID firstIndivSampleId = individualId * ploidy;
-                for (NodeID c = 0; c < ploidy; c++) {
-                    if (m_nodeIdMap.at(firstIndivSampleId + c) == INVALID_NODE_ID) {
-                        fullIndividual = false;
-                        break;
-                    }
-                }
-                if (fullIndividual) {
-                    fullIndividuals.push_back(individualId);
+        // Now check to see if we have this full individual. That means that nodeIdMap
+        // should have all PLOIDY consecutive haplotypes, and they should be in order.
+        if ((sampleId % ploidy) == (ploidy - 1)) {
+            bool fullIndividual = true;
+            const NodeID individualId = sampleId / ploidy;
+            const NodeID firstIndivSampleId = individualId * ploidy;
+            for (NodeID c = 0; c < ploidy; c++) {
+                if (m_nodeIdMap.at(firstIndivSampleId + c) == INVALID_NODE_ID) {
+                    fullIndividual = false;
+                    break;
                 }
             }
+            if (fullIndividual) {
+                fullIndividuals.push_back(individualId);
+            }
         }
-        prevSampleId = sampleId;
     }
-    // Drop the individual IDs and (optionally) warn the user if we have filted by anything other
+    // Drop the individual IDs and (optionally) warn the user if we have filtered by anything other
     // than individuals (e.g., selecting specific haplotypes). The IDs no longer make sense in that case.
     if ((numSamples % ploidy != 0) || (fullIndividuals.size() != numSamples / ploidy)) {
         if (warn) {

--- a/src/util.h
+++ b/src/util.h
@@ -280,4 +280,14 @@ template <typename T> inline void vectReverse(std::vector<T>& vect) {
     }
 }
 
+template <typename T> inline T vectMax(const std::vector<T>& vect) {
+    T maxElem = std::numeric_limits<T>::min();
+    for (size_t i = 0; i < vect.size(); i++) {
+        if (vect[i] > maxElem) {
+            maxElem = vect[i];
+        }
+    }
+    return maxElem;
+}
+
 #endif /* GRGL_UTIL_H */

--- a/test/endtoend/test_modify.py
+++ b/test/endtoend/test_modify.py
@@ -26,7 +26,11 @@ class TestGrgModify(unittest.TestCase):
             os.remove(cls.grg_filename)
 
     def test_downsample(self):
+        self.assertTrue(self.grg.has_individual_ids)
+        self.assertEqual(self.grg.ploidy, 2)
         sub_grg_filename = "test.downsample.grg"
+
+        # This first downsampling does not maintain the diploid samples!
         saved = pygrgl.save_subset(
             self.grg,
             sub_grg_filename,
@@ -37,6 +41,10 @@ class TestGrgModify(unittest.TestCase):
         sub_grg = pygrgl.load_immutable_grg(sub_grg_filename)
         self.assertEqual(sub_grg.num_mutations, self.grg.num_mutations)
         self.assertEqual(sub_grg.num_samples, 20)
+        self.assertFalse(
+            sub_grg.has_individual_ids
+        )  # Individual IDs were broken by the filtering!
+        self.assertEqual(sub_grg.ploidy, 1)  # As was ploidy
 
         input_full = numpy.zeros((1, self.grg.num_samples), dtype=numpy.int32)
         for i in range(0, 200, 10):
@@ -50,6 +58,33 @@ class TestGrgModify(unittest.TestCase):
 
         self.assertEqual(acount_full.shape, acount_sub.shape)
         numpy.testing.assert_array_equal(acount_full, acount_sub)
+
+        # Now keep the individual IDs and reorder some samples.
+        orig_10 = self.grg.get_individual_id(5)
+        saved = pygrgl.save_subset(
+            self.grg,
+            sub_grg_filename,
+            pygrgl.TraversalDirection.UP,
+            [10, 11, 0, 1, 98, 99, 78, 79],
+        )
+        self.assertTrue(saved)
+        sub_grg = pygrgl.load_immutable_grg(sub_grg_filename)
+        self.assertEqual(sub_grg.num_mutations, self.grg.num_mutations)
+        self.assertEqual(sub_grg.num_samples, 8)
+        # Ploidy / individual mapping was retained!
+        self.assertEqual(sub_grg.num_individuals, 4)
+        self.assertTrue(sub_grg.has_individual_ids)
+        self.assertEqual(sub_grg.ploidy, 2)
+        self.assertEqual(orig_10, sub_grg.get_individual_id(0))
+
+        # Keep the same sample twice - should fail
+        with self.assertRaises(RuntimeError):
+            saved = pygrgl.save_subset(
+                self.grg,
+                sub_grg_filename,
+                pygrgl.TraversalDirection.UP,
+                [0, 1, 2, 3, 1],
+            )
 
     def test_downsample_fail(self):
         sub_grg_filename = "test.downsample.fail.grg"


### PR DESCRIPTION
Most genetic dataset tools (e.g., bcftools) will reorder samples when you select a subset of them during filtering, based on the order that you specify the subset in. GRG now does this also.

Added some improved test coverage for downsampling also.